### PR TITLE
feat: ✨ implement myxo init command

### DIFF
--- a/src/myxo/cli.py
+++ b/src/myxo/cli.py
@@ -1,5 +1,7 @@
 """Myxo CLI — uv + typer entrypoint."""
 
+from pathlib import Path
+
 import typer
 
 app = typer.Typer(
@@ -7,11 +9,29 @@ app = typer.Typer(
     help="Myxo — AI Agent Infrastructure Platform.",
 )
 
+_DEFAULT_CONFIG = "# Myxo repository configuration\nversion: \"0.1\"\n"
+_DEFAULT_RULES = "# Myxo Rules\n"
+_SUBDIRS = ("protocols", "procedures", "pseudopods")
+
 
 @app.command()
 def init() -> None:
     """Initialize a new .myxo/ configuration in the current repository."""
-    typer.echo("myxo init: not yet implemented")
+    myxo_dir = Path.cwd() / ".myxo"
+
+    if myxo_dir.exists():
+        typer.echo(".myxo/ already exists — skipping initialization.")
+        return
+
+    myxo_dir.mkdir()
+
+    (myxo_dir / "config.yaml").write_text(_DEFAULT_CONFIG)
+    (myxo_dir / "rules.md").write_text(_DEFAULT_RULES)
+
+    for subdir in _SUBDIRS:
+        sub = myxo_dir / subdir
+        sub.mkdir()
+        (sub / ".gitkeep").touch()
 
 
 @app.command()

--- a/src/myxo/cli.py
+++ b/src/myxo/cli.py
@@ -20,6 +20,12 @@ def init() -> None:
     myxo_dir = Path.cwd() / ".myxo"
 
     if myxo_dir.exists():
+        if not myxo_dir.is_dir():
+            typer.echo(
+                ".myxo exists but is not a directory. "
+                "Please remove or rename it before running `myxo init`."
+            )
+            raise typer.Exit(code=1)
         typer.echo(".myxo/ already exists — skipping initialization.")
         return
 

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -1,0 +1,81 @@
+"""Tests for myxo init command."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from myxo.cli import app
+
+runner = CliRunner()
+
+
+def test_init_creates_myxo_directory(tmp_path: Path, monkeypatch):
+    """myxo init should create .myxo/ directory in the current working directory."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    assert (tmp_path / ".myxo").is_dir()
+
+
+def test_init_creates_config_yaml(tmp_path: Path, monkeypatch):
+    """myxo init should create .myxo/config.yaml with default content."""
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init"])
+    config = tmp_path / ".myxo" / "config.yaml"
+    assert config.is_file()
+    content = config.read_text()
+    assert "version" in content
+
+
+def test_init_creates_rules_md(tmp_path: Path, monkeypatch):
+    """myxo init should create .myxo/rules.md."""
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init"])
+    assert (tmp_path / ".myxo" / "rules.md").is_file()
+
+
+def test_init_creates_subdirectories(tmp_path: Path, monkeypatch):
+    """myxo init should create protocols/, procedures/, pseudopods/ subdirectories."""
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init"])
+    myxo = tmp_path / ".myxo"
+    assert (myxo / "protocols").is_dir()
+    assert (myxo / "procedures").is_dir()
+    assert (myxo / "pseudopods").is_dir()
+
+
+def test_init_creates_gitkeep_in_subdirectories(tmp_path: Path, monkeypatch):
+    """Subdirectories should contain .gitkeep files."""
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init"])
+    myxo = tmp_path / ".myxo"
+    assert (myxo / "protocols" / ".gitkeep").is_file()
+    assert (myxo / "procedures" / ".gitkeep").is_file()
+    assert (myxo / "pseudopods" / ".gitkeep").is_file()
+
+
+def test_init_twice_does_not_overwrite(tmp_path: Path, monkeypatch):
+    """Running init twice should not overwrite existing files."""
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init"])
+
+    # Modify config.yaml with custom content
+    config = tmp_path / ".myxo" / "config.yaml"
+    config.write_text("version: \"0.2\"\ncustom: true\n")
+
+    # Run init again
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+
+    # Existing file should not be overwritten
+    content = config.read_text()
+    assert "custom: true" in content
+
+
+def test_init_twice_shows_warning(tmp_path: Path, monkeypatch):
+    """Running init when .myxo/ already exists should show a message."""
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    assert "already exists" in result.stdout.lower()

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -20,7 +20,8 @@ def test_init_creates_myxo_directory(tmp_path: Path, monkeypatch):
 def test_init_creates_config_yaml(tmp_path: Path, monkeypatch):
     """myxo init should create .myxo/config.yaml with default content."""
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
     config = tmp_path / ".myxo" / "config.yaml"
     assert config.is_file()
     content = config.read_text()
@@ -30,14 +31,16 @@ def test_init_creates_config_yaml(tmp_path: Path, monkeypatch):
 def test_init_creates_rules_md(tmp_path: Path, monkeypatch):
     """myxo init should create .myxo/rules.md."""
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
     assert (tmp_path / ".myxo" / "rules.md").is_file()
 
 
 def test_init_creates_subdirectories(tmp_path: Path, monkeypatch):
     """myxo init should create protocols/, procedures/, pseudopods/ subdirectories."""
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
     myxo = tmp_path / ".myxo"
     assert (myxo / "protocols").is_dir()
     assert (myxo / "procedures").is_dir()
@@ -47,17 +50,28 @@ def test_init_creates_subdirectories(tmp_path: Path, monkeypatch):
 def test_init_creates_gitkeep_in_subdirectories(tmp_path: Path, monkeypatch):
     """Subdirectories should contain .gitkeep files."""
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
     myxo = tmp_path / ".myxo"
     assert (myxo / "protocols" / ".gitkeep").is_file()
     assert (myxo / "procedures" / ".gitkeep").is_file()
     assert (myxo / "pseudopods" / ".gitkeep").is_file()
 
 
+def test_init_fails_when_myxo_is_file(tmp_path: Path, monkeypatch):
+    """myxo init should fail if .myxo exists as a file."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".myxo").write_text("not a directory")
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 1
+    assert "not a directory" in result.stdout.lower()
+
+
 def test_init_twice_does_not_overwrite(tmp_path: Path, monkeypatch):
     """Running init twice should not overwrite existing files."""
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
 
     # Modify config.yaml with custom content
     config = tmp_path / ".myxo" / "config.yaml"
@@ -75,7 +89,8 @@ def test_init_twice_does_not_overwrite(tmp_path: Path, monkeypatch):
 def test_init_twice_shows_warning(tmp_path: Path, monkeypatch):
     """Running init when .myxo/ already exists should show a message."""
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0
     assert "already exists" in result.stdout.lower()


### PR DESCRIPTION
## Summary
Implement `myxo init` command to scaffold `.myxo/` directory structure
in the current working directory. Creates config.yaml, rules.md,
and subdirectories (protocols/, procedures/, pseudopods/) with .gitkeep files.
Idempotent — skips with warning if `.myxo/` already exists.
Fails with exit code 1 if `.myxo` exists as a file.

Refs #7