### PR TITLE
chore: 🔧 add pr-rules skill and PR title lint CI

### DIFF
--- a/.claude/skills/commit-rules/SKILL.md
+++ b/.claude/skills/commit-rules/SKILL.md
@@ -120,32 +120,9 @@ refactor: ♻️ extract experiment validation logic ← refactor (tests still p
 
 ## Pull Request Rules
 
-### PR Title Format
+See `pr-rules` skill for full PR creation rules (merge strategy, labels, milestones, assignees).
 
-```
-<type>: <emoji> <subject>
-```
-
-- Max 70 characters
-- Same type/emoji rules as commit messages
-- Examples:
-  - `feat: ✨ add pseudopod task execution`
-  - `fix: 🐛 resolve experiment scheduling race condition`
-  - `chore: 🔧 add PR title validation`
-
-### PR Body
-
-- **Summary**: Describe changes in 1-3 sentences
-- **Changes**: List key changes
-- **Why**: Explain motivation
-- **Test Plan**: Verification steps as checklist
-- **Related**: Reference issues with `Closes #` / `Refs #`
-
-### General
-
-- All PRs must reference related issues when applicable
-- Test Plan must include verification steps
-- Summary section must not be empty
+PR titles follow the same format as commit messages (squash merge makes the title the final commit).
 
 ## Language
 

--- a/.claude/skills/pr-rules/SKILL.md
+++ b/.claude/skills/pr-rules/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: pr-rules
+description: PR creation rules for Myxo Lab. Enforces squash merge conventions, title format, labels, milestones, and assignees. Reference this when creating pull requests.
+user-invocable: false
+---
+
+# Pull Request Rules
+
+## Merge Strategy
+
+| Target branch | Merge method | Why |
+|---------------|-------------|-----|
+| `develop` | **Squash merge** | Clean history — PR title becomes the commit message |
+| `main` | **Merge commit** | Preserve develop history on release |
+
+Because PRs to `develop` are squash-merged, the **PR title IS the final commit message**. Follow commit-rules format exactly.
+
+## PR Title Format
+
+```
+<type>: <emoji> <subject>
+```
+
+- Same rules as commit messages (see commit-rules skill)
+- English, lowercase start, no trailing period, imperative mood
+- Max 70 characters
+- Examples:
+  - `feat: ✨ implement myxo init command`
+  - `fix: 🐛 resolve experiment scheduling race condition`
+
+## PR Body Template
+
+```markdown
+## Summary
+<1-3 sentences describing the change>
+
+## Test plan
+- [ ] Verification steps as checklist
+
+Closes #<issue>
+```
+
+- `Closes #N` for issues being resolved, `Refs #N` for related issues
+- All PRs must reference related issues when applicable
+
+## Labels
+
+Use existing labels from the repository. Match based on the change:
+
+| Category | Labels |
+|----------|--------|
+| Layer | `layer: cli`, `layer: infra`, `layer: workflow`, `layer: github`, `layer: security` |
+| Priority | `priority: critical`, `priority: high`, `priority: medium`, `priority: low` |
+
+Do NOT create new labels. If no label fits, omit it.
+
+## Milestone
+
+Assign the appropriate milestone based on the issue being closed:
+
+| Milestone | When |
+|-----------|------|
+| `Phase 1: PoC` | Foundation, CLI, Pulumi, GitHub Actions, MCP, security |
+| `Phase 2: 本番化` | Temporal, Protocol/Assay agents, GitHub App |
+| `Phase 3: 拡張` | OSS release, cost monitoring, auto-rollback |
+
+## Assignee
+
+Always assign the PR to the current GitHub user (the operator running Claude Code).
+Determine with: `gh api user --jq '.login'`
+
+## Branch Strategy
+
+- Feature branches: `feature/<name>` from `develop`
+- PRs target: `develop`
+- `main` is protected — no direct pushes
+
+## gh pr create Example
+
+```bash
+ASSIGNEE=$(gh api user --jq '.login')
+gh pr create \
+  --base develop \
+  --title "feat: ✨ implement myxo init command" \
+  --label "layer: cli" \
+  --milestone "Phase 1: PoC" \
+  --assignee "$ASSIGNEE" \
+  --body "$(cat <<'EOF'
+## Summary
+Implement `myxo init` to scaffold `.myxo/` directory structure.
+
+## Test plan
+- [x] `uv run pytest -v` passes all tests
+- [x] `myxo init` creates expected directory structure
+
+Closes #7
+EOF
+)"
+```
+
+## Language
+
+All PR titles and descriptions must be in **English**.

--- a/.claude/skills/pr-rules/SKILL.md
+++ b/.claude/skills/pr-rules/SKILL.md
@@ -34,14 +34,24 @@ Because PRs to `develop` are squash-merged, the **PR title IS the final commit m
 ## Summary
 <1-3 sentences describing the change>
 
-## Test plan
-- [ ] Verification steps as checklist
-
 Closes #<issue>
 ```
 
 - `Closes #N` for issues being resolved, `Refs #N` for related issues
 - All PRs must reference related issues when applicable
+- **Do NOT include Test plan in the PR body**
+
+## Test Plan Comment
+
+After creating the PR, post a **separate comment** with the test plan:
+
+```bash
+gh pr comment <PR_NUMBER> --repo June3141/myxo-lab --body "$(cat <<'EOF'
+## Test plan
+- [x] Verification steps as checklist
+EOF
+)"
+```
 
 ## Labels
 
@@ -79,6 +89,8 @@ Determine with: `gh api user --jq '.login'`
 
 ```bash
 ASSIGNEE=$(gh api user --jq '.login')
+
+# Step 1: Create PR (no test plan in body)
 gh pr create \
   --base develop \
   --title "feat: ✨ implement myxo init command" \
@@ -89,11 +101,15 @@ gh pr create \
 ## Summary
 Implement `myxo init` to scaffold `.myxo/` directory structure.
 
+Closes #7
+EOF
+)"
+
+# Step 2: Post test plan as separate comment
+gh pr comment <PR_NUMBER> --repo June3141/myxo-lab --body "$(cat <<'EOF'
 ## Test plan
 - [x] `uv run pytest -v` passes all tests
 - [x] `myxo init` creates expected directory structure
-
-Closes #7
 EOF
 )"
 ```

--- a/.github/scripts/pr-title-lint.py
+++ b/.github/scripts/pr-title-lint.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate PR title matches the gitmoji commit format.
+
+Usage: pr-title-lint.py "<title>"
+Exit 0 on valid, 1 on invalid.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+TYPES = {"feat", "fix", "docs", "test", "refactor", "chore", "style", "perf"}
+
+# Load gitmoji pattern from the hook file
+_pattern_file = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "gitmoji-pattern.txt"
+if _pattern_file.exists():
+    _emojis = _pattern_file.read_text().strip().split("|")
+else:
+    # Fallback: common gitmoji set
+    _emojis = ["✨", "🐛", "📝", "✅", "♻️", "🔧", "🎨", "⚡️", "🔥", "💥", "🚀", "🚧", "🔒", "⬆️", "🗃️", "🎉"]
+
+_emoji_pattern = "|".join(re.escape(e) for e in _emojis)
+
+# Pattern: <type>: <emoji> <lowercase subject, no trailing period>
+TITLE_RE = re.compile(
+    rf"^(?:{'|'.join(TYPES)}): (?:{_emoji_pattern}) [a-z].*[^.]$"
+)
+
+MAX_LENGTH = 70
+
+
+def validate(title: str) -> str | None:
+    """Return error message or None if valid."""
+    if not title:
+        return "Title is empty"
+    if len(title) > MAX_LENGTH:
+        return f"Title exceeds {MAX_LENGTH} characters ({len(title)})"
+    if not TITLE_RE.match(title):
+        return f"Title does not match format: <type>: <emoji> <subject>"
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <title>", file=sys.stderr)
+        return 2
+
+    title = sys.argv[1]
+    error = validate(title)
+    if error:
+        print(f"❌ {error}", file=sys.stderr)
+        print(f"   Got: {title!r}", file=sys.stderr)
+        print(f"   Expected: <type>: <emoji> <subject>", file=sys.stderr)
+        return 1
+
+    print(f"✅ Title OK: {title}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/pr-title-lint.py
+++ b/.github/scripts/pr-title-lint.py
@@ -2,7 +2,7 @@
 """Validate PR title matches the gitmoji commit format.
 
 Usage: pr-title-lint.py "<title>"
-Exit 0 on valid, 1 on invalid.
+Exit codes: 0 on valid, 1 on invalid title, 2 on usage/argument error.
 """
 
 import re
@@ -23,7 +23,7 @@ _emoji_pattern = "|".join(re.escape(e) for e in _emojis)
 
 # Pattern: <type>: <emoji> <lowercase subject, no trailing period>
 TITLE_RE = re.compile(
-    rf"^(?:{'|'.join(TYPES)}): (?:{_emoji_pattern}) [a-z].*[^.]$"
+    rf"^(?:{'|'.join(TYPES)}): (?:{_emoji_pattern}) [a-z].*(?<!\.)$"
 )
 
 MAX_LENGTH = 70

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,17 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python .github/scripts/pr-title-lint.py "$PR_TITLE"

--- a/tests/test_pr_title_lint.py
+++ b/tests/test_pr_title_lint.py
@@ -45,6 +45,11 @@ def test_valid_refactor_title():
     assert result.returncode == 0
 
 
+def test_valid_min_length_subject():
+    result = _run("feat: ✨ a")
+    assert result.returncode == 0
+
+
 def test_reject_missing_emoji():
     result = _run("feat: add something")
     assert result.returncode == 1

--- a/tests/test_pr_title_lint.py
+++ b/tests/test_pr_title_lint.py
@@ -1,0 +1,75 @@
+"""Tests for PR title lint script."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / ".github" / "scripts" / "pr-title-lint.py"
+
+
+def _run(title: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), title],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_valid_feat_title():
+    result = _run("feat: ✨ add hypothesis tracking endpoint")
+    assert result.returncode == 0
+
+
+def test_valid_fix_title():
+    result = _run("fix: 🐛 resolve scheduling race condition")
+    assert result.returncode == 0
+
+
+def test_valid_chore_title():
+    result = _run("chore: 🔧 add PR title validation")
+    assert result.returncode == 0
+
+
+def test_valid_test_title():
+    result = _run("test: ✅ add pseudopod execution tests")
+    assert result.returncode == 0
+
+
+def test_valid_docs_title():
+    result = _run("docs: 📝 update architecture diagram")
+    assert result.returncode == 0
+
+
+def test_valid_refactor_title():
+    result = _run("refactor: ♻️ extract experiment validation logic")
+    assert result.returncode == 0
+
+
+def test_reject_missing_emoji():
+    result = _run("feat: add something")
+    assert result.returncode == 1
+
+
+def test_reject_missing_type():
+    result = _run("✨ add something")
+    assert result.returncode == 1
+
+
+def test_reject_uppercase_subject():
+    result = _run("feat: ✨ Add something")
+    assert result.returncode == 1
+
+
+def test_reject_trailing_period():
+    result = _run("feat: ✨ add something.")
+    assert result.returncode == 1
+
+
+def test_reject_too_long():
+    result = _run("feat: ✨ " + "a" * 70)
+    assert result.returncode == 1
+
+
+def test_reject_empty():
+    result = _run("")
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary
- Add `pr-rules` skill defining squash merge strategy, label/milestone/assignee conventions
- Add PR title lint script and GitHub Actions workflow for CI validation
- Update `commit-rules` to reference `pr-rules` for PR-specific details

## Test plan
- [x] `uv run pytest -v` — 22 tests pass (12 new PR title lint tests)
- [x] Lint script validates gitmoji format, rejects bad titles