### PR TITLE
feat: ✨ implement ContextSanitizer for secret scanning

### DIFF
--- a/src/myxo/sanitizer.py
+++ b/src/myxo/sanitizer.py
@@ -19,12 +19,16 @@ class ContextSanitizer:
             re.compile(
                 r"(?:aws_secret_access_key|AWS_SECRET_ACCESS_KEY)"
                 r"\s*[=:]\s*"
-                r"([A-Za-z0-9/+=]{40})"
+                r"[A-Za-z0-9/+=]{40}"
             ),
         ),
         (
             "private-key",
-            re.compile(r"-----BEGIN\s[\w\s]*PRIVATE\sKEY-----"),
+            re.compile(
+                r"-----BEGIN\s[\w\s]*PRIVATE\sKEY-----"
+                r"[\s\S]*?"
+                r"-----END\s[\w\s]*PRIVATE\sKEY-----"
+            ),
         ),
         (
             "jwt",
@@ -38,7 +42,7 @@ class ContextSanitizer:
         ),
         (
             "password",
-            re.compile(r"password\s*=\s*['\"][^'\"]+['\"]"),
+            re.compile(r"\bpassword\b\s*=\s*['\"][^'\"]+['\"]"),
         ),
     ]
 

--- a/src/myxo/sanitizer.py
+++ b/src/myxo/sanitizer.py
@@ -1,0 +1,54 @@
+"""ContextSanitizer — detect and redact secrets before sending to LLM."""
+
+from __future__ import annotations
+
+import re
+from typing import ClassVar
+
+
+class ContextSanitizer:
+    """Scans text for common secret patterns and replaces them with redaction markers."""
+
+    _PATTERNS: ClassVar[list[tuple[str, re.Pattern[str]]]] = [
+        (
+            "aws-access-key",
+            re.compile(r"AKIA[0-9A-Z]{16}"),
+        ),
+        (
+            "aws-secret-key",
+            re.compile(
+                r"(?:aws_secret_access_key|AWS_SECRET_ACCESS_KEY)"
+                r"\s*[=:]\s*"
+                r"([A-Za-z0-9/+=]{40})"
+            ),
+        ),
+        (
+            "private-key",
+            re.compile(r"-----BEGIN\s[\w\s]*PRIVATE\sKEY-----"),
+        ),
+        (
+            "jwt",
+            re.compile(
+                r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
+            ),
+        ),
+        (
+            "github-token",
+            re.compile(r"gh[ps]_[A-Za-z0-9_]{36,}"),
+        ),
+        (
+            "password",
+            re.compile(r"password\s*=\s*['\"][^'\"]+['\"]"),
+        ),
+    ]
+
+    def sanitize(self, text: str) -> str:
+        """Replace detected secrets with ``[REDACTED:<type>]`` markers."""
+        result = text
+        for label, pattern in self._PATTERNS:
+            result = pattern.sub(f"[REDACTED:{label}]", result)
+        return result
+
+    def has_secrets(self, text: str) -> bool:
+        """Return ``True`` if *text* contains any recognised secret pattern."""
+        return any(pattern.search(text) for _, pattern in self._PATTERNS)

--- a/src/myxo/sanitizer.py
+++ b/src/myxo/sanitizer.py
@@ -9,18 +9,11 @@ from typing import ClassVar
 class ContextSanitizer:
     """Scans text for common secret patterns and replaces them with redaction markers."""
 
+    # Patterns that use a simple full-match replacement.
     _PATTERNS: ClassVar[list[tuple[str, re.Pattern[str]]]] = [
         (
             "aws-access-key",
             re.compile(r"AKIA[0-9A-Z]{16}"),
-        ),
-        (
-            "aws-secret-key",
-            re.compile(
-                r"(?:aws_secret_access_key|AWS_SECRET_ACCESS_KEY)"
-                r"\s*[=:]\s*"
-                r"[A-Za-z0-9/+=]{40}"
-            ),
         ),
         (
             "private-key",
@@ -38,11 +31,38 @@ class ContextSanitizer:
         ),
         (
             "github-token",
-            re.compile(r"gh[ps]_[A-Za-z0-9_]{36,}"),
+            re.compile(
+                r"(?:github_pat_[A-Za-z0-9_]{22,}"
+                r"|gh[psourx]_[A-Za-z0-9_]{36,})"
+            ),
+        ),
+    ]
+
+    # Patterns where only the *value* should be redacted (key name is preserved).
+    # Each tuple: (label, compiled pattern with a ``value`` named group).
+    _KEY_VALUE_PATTERNS: ClassVar[list[tuple[str, re.Pattern[str]]]] = [
+        (
+            "aws-secret-key",
+            re.compile(
+                r"(?P<key>(?:aws_secret_access_key|AWS_SECRET_ACCESS_KEY)"
+                r"\s*[=:]\s*)"
+                r"(?P<value>[A-Za-z0-9/+=]{40})"
+            ),
         ),
         (
             "password",
-            re.compile(r"\bpassword\b\s*=\s*['\"][^'\"]+['\"]"),
+            re.compile(
+                r"(?P<key>\bpassword\b\s*=\s*)"
+                r"(?P<value>['\"][^'\"]+['\"])"
+            ),
+        ),
+        (
+            "api-key",
+            re.compile(
+                r"(?P<key>\bapi[_-]?(?:key|secret)\b\s*[=:]\s*)"
+                r"(?P<value>['\"][^'\"]+['\"]|[^\s,;'\"]+)",
+                re.IGNORECASE,
+            ),
         ),
     ]
 
@@ -51,8 +71,14 @@ class ContextSanitizer:
         result = text
         for label, pattern in self._PATTERNS:
             result = pattern.sub(f"[REDACTED:{label}]", result)
+        for label, pattern in self._KEY_VALUE_PATTERNS:
+            result = pattern.sub(
+                rf"\g<key>[REDACTED:{label}]", result,
+            )
         return result
 
     def has_secrets(self, text: str) -> bool:
         """Return ``True`` if *text* contains any recognised secret pattern."""
-        return any(pattern.search(text) for _, pattern in self._PATTERNS)
+        return any(pattern.search(text) for _, pattern in self._PATTERNS) or any(
+            pattern.search(text) for _, pattern in self._KEY_VALUE_PATTERNS
+        )

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -3,151 +3,185 @@
 from myxo.sanitizer import ContextSanitizer
 
 
-class TestSanitizeAWSAccessKey:
-    """AWS Access Key ID pattern: AKIA followed by 16 uppercase alphanumeric chars."""
-
-    def test_redacts_aws_access_key(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"
-        result = sanitizer.sanitize(text)
-        assert "AKIAIOSFODNN7EXAMPLE" not in result
-        assert "[REDACTED:aws-access-key]" in result
-
-    def test_has_secrets_detects_aws_access_key(self) -> None:
-        sanitizer = ContextSanitizer()
-        assert sanitizer.has_secrets("key = AKIAIOSFODNN7EXAMPLE")
+# --- AWS Access Key ---
 
 
-class TestSanitizeAWSSecretKey:
-    """AWS Secret Access Key: 40-char base64 after common prefixes."""
-
-    def test_redacts_aws_secret_key(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-        result = sanitizer.sanitize(text)
-        assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in result
-        assert "[REDACTED:aws-secret-key]" in result
-
-    def test_has_secrets_detects_aws_secret_key(self) -> None:
-        sanitizer = ContextSanitizer()
-        assert sanitizer.has_secrets(
-            "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-        )
+def test_redacts_aws_access_key() -> None:
+    sanitizer = ContextSanitizer()
+    text = "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"
+    result = sanitizer.sanitize(text)
+    assert "AKIAIOSFODNN7EXAMPLE" not in result
+    assert "[REDACTED:aws-access-key]" in result
 
 
-class TestSanitizePrivateKey:
-    """Private Key blocks: -----BEGIN ... PRIVATE KEY-----."""
-
-    def test_redacts_private_key_header(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALR..."
-        result = sanitizer.sanitize(text)
-        assert "-----BEGIN RSA PRIVATE KEY-----" not in result
-        assert "[REDACTED:private-key]" in result
-
-    def test_redacts_ec_private_key(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "-----BEGIN EC PRIVATE KEY-----"
-        result = sanitizer.sanitize(text)
-        assert "[REDACTED:private-key]" in result
+def test_has_secrets_detects_aws_access_key() -> None:
+    sanitizer = ContextSanitizer()
+    assert sanitizer.has_secrets("key = AKIAIOSFODNN7EXAMPLE")
 
 
-class TestSanitizeJWT:
-    """JWT tokens: eyJ... three base64url segments separated by dots."""
-
-    def test_redacts_jwt_token(self) -> None:
-        sanitizer = ContextSanitizer()
-        token = (
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-            ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0"
-            ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-        )
-        text = f"Authorization: Bearer {token}"
-        result = sanitizer.sanitize(text)
-        assert token not in result
-        assert "[REDACTED:jwt]" in result
+# --- AWS Secret Key ---
 
 
-class TestSanitizePassword:
-    """Generic password patterns: password = '...' or password = "..."."""
-
-    def test_redacts_password_single_quotes(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "password = 'super_secret_123'"
-        result = sanitizer.sanitize(text)
-        assert "super_secret_123" not in result
-        assert "[REDACTED:password]" in result
-
-    def test_redacts_password_double_quotes(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = 'password = "my-database-pw!"'
-        result = sanitizer.sanitize(text)
-        assert "my-database-pw!" not in result
-        assert "[REDACTED:password]" in result
-
-    def test_redacts_password_no_spaces(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "password='compact_secret'"
-        result = sanitizer.sanitize(text)
-        assert "compact_secret" not in result
-        assert "[REDACTED:password]" in result
+def test_redacts_aws_secret_key() -> None:
+    sanitizer = ContextSanitizer()
+    text = "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    result = sanitizer.sanitize(text)
+    assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in result
+    assert "[REDACTED:aws-secret-key]" in result
 
 
-class TestSanitizeGitHubToken:
-    """GitHub tokens: ghp_ or ghs_ followed by 36+ alphanumeric chars."""
-
-    def test_redacts_github_pat(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
-        result = sanitizer.sanitize(text)
-        assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl" not in result
-        assert "[REDACTED:github-token]" in result
-
-    def test_redacts_github_server_token(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "token: ghs_1234567890abcdefghijklmnopqrstuvwxyz"
-        result = sanitizer.sanitize(text)
-        assert "ghs_1234567890abcdefghijklmnopqrstuvwxyz" not in result
-        assert "[REDACTED:github-token]" in result
+def test_has_secrets_detects_aws_secret_key() -> None:
+    sanitizer = ContextSanitizer()
+    assert sanitizer.has_secrets(
+        "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    )
 
 
-class TestCleanTextPassthrough:
-    """Clean text without secrets should pass through unchanged."""
-
-    def test_clean_text_unchanged(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "This is a normal log message with no secrets."
-        assert sanitizer.sanitize(text) == text
-
-    def test_has_secrets_returns_false_for_clean_text(self) -> None:
-        sanitizer = ContextSanitizer()
-        assert not sanitizer.has_secrets("Just some regular code: x = 42")
-
-    def test_code_with_password_word_but_no_value(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "# Enter your password below"
-        assert sanitizer.sanitize(text) == text
-        assert not sanitizer.has_secrets(text)
+# --- Private Key ---
 
 
-class TestMultipleSecrets:
-    """Multiple secrets in one text should all be redacted."""
+def test_redacts_private_key_header() -> None:
+    sanitizer = ContextSanitizer()
+    text = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALR...\n-----END RSA PRIVATE KEY-----"
+    result = sanitizer.sanitize(text)
+    assert "-----BEGIN RSA PRIVATE KEY-----" not in result
+    assert "[REDACTED:private-key]" in result
 
-    def test_redacts_multiple_different_secrets(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = (
-            "aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n"
-            "password = 'db_secret_pass'\n"
-            "GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl\n"
-        )
-        result = sanitizer.sanitize(text)
-        assert "[REDACTED:aws-access-key]" in result
-        assert "[REDACTED:password]" in result
-        assert "[REDACTED:github-token]" in result
-        assert "AKIAIOSFODNN7EXAMPLE" not in result
-        assert "db_secret_pass" not in result
 
-    def test_has_secrets_true_with_multiple(self) -> None:
-        sanitizer = ContextSanitizer()
-        text = "AKIAIOSFODNN7EXAMPLE and password = 'oops'"
-        assert sanitizer.has_secrets(text)
+def test_redacts_ec_private_key() -> None:
+    sanitizer = ContextSanitizer()
+    text = "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEE...\n-----END EC PRIVATE KEY-----"
+    result = sanitizer.sanitize(text)
+    assert "[REDACTED:private-key]" in result
+
+
+def test_redacts_full_pem_block() -> None:
+    """Multi-line PEM key body (base64 payload) is fully redacted."""
+    sanitizer = ContextSanitizer()
+    text = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF068wEJ8HPXEY2UQxHOm\n"
+        "WsLOGpKx3KNDB+sFm1jMCH4a0gKsVd3vOEJMPqGP6xHPE36d3DCPIZ+\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    result = sanitizer.sanitize(text)
+    assert "MIIEowIBAAKCAQEA0Z3VS5JJcds3xfn" not in result
+    assert "WsLOGpKx3KNDB+sFm1jMCH4a0gKsVd3vOEJMPqGP6xHPE36d3DCPIZ+" not in result
+    assert "-----BEGIN RSA PRIVATE KEY-----" not in result
+    assert "-----END RSA PRIVATE KEY-----" not in result
+    assert "[REDACTED:private-key]" in result
+
+
+# --- JWT ---
+
+
+def test_redacts_jwt_token() -> None:
+    sanitizer = ContextSanitizer()
+    token = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+        ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0"
+        ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+    text = f"Authorization: Bearer {token}"
+    result = sanitizer.sanitize(text)
+    assert token not in result
+    assert "[REDACTED:jwt]" in result
+
+
+# --- Password ---
+
+
+def test_redacts_password_single_quotes() -> None:
+    sanitizer = ContextSanitizer()
+    text = "password = 'super_secret_123'"
+    result = sanitizer.sanitize(text)
+    assert "super_secret_123" not in result
+    assert "[REDACTED:password]" in result
+
+
+def test_redacts_password_double_quotes() -> None:
+    sanitizer = ContextSanitizer()
+    text = 'password = "my-database-pw!"'
+    result = sanitizer.sanitize(text)
+    assert "my-database-pw!" not in result
+    assert "[REDACTED:password]" in result
+
+
+def test_redacts_password_no_spaces() -> None:
+    sanitizer = ContextSanitizer()
+    text = "password='compact_secret'"
+    result = sanitizer.sanitize(text)
+    assert "compact_secret" not in result
+    assert "[REDACTED:password]" in result
+
+
+def test_password_word_boundary_no_false_positive() -> None:
+    """Words like 'mypassword' should NOT trigger redaction."""
+    sanitizer = ContextSanitizer()
+    text = "mypassword = 'not_a_match'"
+    assert sanitizer.sanitize(text) == text
+    assert not sanitizer.has_secrets(text)
+
+
+# --- GitHub Token ---
+
+
+def test_redacts_github_pat() -> None:
+    sanitizer = ContextSanitizer()
+    text = "GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+    result = sanitizer.sanitize(text)
+    assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl" not in result
+    assert "[REDACTED:github-token]" in result
+
+
+def test_redacts_github_server_token() -> None:
+    sanitizer = ContextSanitizer()
+    text = "token: ghs_1234567890abcdefghijklmnopqrstuvwxyz"
+    result = sanitizer.sanitize(text)
+    assert "ghs_1234567890abcdefghijklmnopqrstuvwxyz" not in result
+    assert "[REDACTED:github-token]" in result
+
+
+# --- Clean text passthrough ---
+
+
+def test_clean_text_unchanged() -> None:
+    sanitizer = ContextSanitizer()
+    text = "This is a normal log message with no secrets."
+    assert sanitizer.sanitize(text) == text
+
+
+def test_has_secrets_returns_false_for_clean_text() -> None:
+    sanitizer = ContextSanitizer()
+    assert not sanitizer.has_secrets("Just some regular code: x = 42")
+
+
+def test_code_with_password_word_but_no_value() -> None:
+    sanitizer = ContextSanitizer()
+    text = "# Enter your password below"
+    assert sanitizer.sanitize(text) == text
+    assert not sanitizer.has_secrets(text)
+
+
+# --- Multiple secrets ---
+
+
+def test_redacts_multiple_different_secrets() -> None:
+    sanitizer = ContextSanitizer()
+    text = (
+        "aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n"
+        "password = 'db_secret_pass'\n"
+        "GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl\n"
+    )
+    result = sanitizer.sanitize(text)
+    assert "[REDACTED:aws-access-key]" in result
+    assert "[REDACTED:password]" in result
+    assert "[REDACTED:github-token]" in result
+    assert "AKIAIOSFODNN7EXAMPLE" not in result
+    assert "db_secret_pass" not in result
+
+
+def test_has_secrets_true_with_multiple() -> None:
+    sanitizer = ContextSanitizer()
+    text = "AKIAIOSFODNN7EXAMPLE and password = 'oops'"
+    assert sanitizer.has_secrets(text)

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -28,6 +28,8 @@ def test_redacts_aws_secret_key() -> None:
     result = sanitizer.sanitize(text)
     assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in result
     assert "[REDACTED:aws-secret-key]" in result
+    # Key name must be preserved
+    assert "aws_secret_access_key = " in result
 
 
 def test_has_secrets_detects_aws_secret_key() -> None:
@@ -97,6 +99,8 @@ def test_redacts_password_single_quotes() -> None:
     result = sanitizer.sanitize(text)
     assert "super_secret_123" not in result
     assert "[REDACTED:password]" in result
+    # Key name must be preserved
+    assert result.startswith("password = ")
 
 
 def test_redacts_password_double_quotes() -> None:
@@ -105,6 +109,7 @@ def test_redacts_password_double_quotes() -> None:
     result = sanitizer.sanitize(text)
     assert "my-database-pw!" not in result
     assert "[REDACTED:password]" in result
+    assert result.startswith("password = ")
 
 
 def test_redacts_password_no_spaces() -> None:
@@ -113,6 +118,7 @@ def test_redacts_password_no_spaces() -> None:
     result = sanitizer.sanitize(text)
     assert "compact_secret" not in result
     assert "[REDACTED:password]" in result
+    assert result.startswith("password=")
 
 
 def test_password_word_boundary_no_false_positive() -> None:
@@ -140,6 +146,73 @@ def test_redacts_github_server_token() -> None:
     result = sanitizer.sanitize(text)
     assert "ghs_1234567890abcdefghijklmnopqrstuvwxyz" not in result
     assert "[REDACTED:github-token]" in result
+
+
+def test_redacts_github_fine_grained_pat() -> None:
+    sanitizer = ContextSanitizer()
+    text = "token=github_pat_ABCDEF1234567890ABCDEF12_abcdefghijklmnopqrstuvwxyz1234567890ABCDEF1234567890abcdefgh"
+    result = sanitizer.sanitize(text)
+    assert "github_pat_" not in result
+    assert "[REDACTED:github-token]" in result
+
+
+def test_redacts_github_oauth_token() -> None:
+    sanitizer = ContextSanitizer()
+    text = "token: gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+    result = sanitizer.sanitize(text)
+    assert "gho_" not in result
+    assert "[REDACTED:github-token]" in result
+
+
+def test_redacts_github_user_token() -> None:
+    sanitizer = ContextSanitizer()
+    text = "token: ghu_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+    result = sanitizer.sanitize(text)
+    assert "ghu_" not in result
+    assert "[REDACTED:github-token]" in result
+
+
+# --- Generic API Key ---
+
+
+def test_redacts_api_key_double_quotes() -> None:
+    sanitizer = ContextSanitizer()
+    text = 'api_key = "sk-abc123xyz"'
+    result = sanitizer.sanitize(text)
+    assert "sk-abc123xyz" not in result
+    assert "[REDACTED:api-key]" in result
+    assert result.startswith("api_key = ")
+
+
+def test_redacts_api_secret_colon() -> None:
+    sanitizer = ContextSanitizer()
+    text = "api_secret: my_super_secret_value"
+    result = sanitizer.sanitize(text)
+    assert "my_super_secret_value" not in result
+    assert "[REDACTED:api-key]" in result
+    assert result.startswith("api_secret: ")
+
+
+def test_redacts_apikey_no_separator() -> None:
+    sanitizer = ContextSanitizer()
+    text = "apikey='tok_live_12345'"
+    result = sanitizer.sanitize(text)
+    assert "tok_live_12345" not in result
+    assert "[REDACTED:api-key]" in result
+    assert result.startswith("apikey=")
+
+
+def test_redacts_api_key_case_insensitive() -> None:
+    sanitizer = ContextSanitizer()
+    text = 'API_KEY = "SECRETVALUE"'
+    result = sanitizer.sanitize(text)
+    assert "SECRETVALUE" not in result
+    assert "[REDACTED:api-key]" in result
+
+
+def test_has_secrets_detects_api_key() -> None:
+    sanitizer = ContextSanitizer()
+    assert sanitizer.has_secrets("api_key=something")
 
 
 # --- Clean text passthrough ---

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -1,0 +1,153 @@
+"""Tests for ContextSanitizer — secret scanning before LLM."""
+
+from myxo.sanitizer import ContextSanitizer
+
+
+class TestSanitizeAWSAccessKey:
+    """AWS Access Key ID pattern: AKIA followed by 16 uppercase alphanumeric chars."""
+
+    def test_redacts_aws_access_key(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"
+        result = sanitizer.sanitize(text)
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert "[REDACTED:aws-access-key]" in result
+
+    def test_has_secrets_detects_aws_access_key(self) -> None:
+        sanitizer = ContextSanitizer()
+        assert sanitizer.has_secrets("key = AKIAIOSFODNN7EXAMPLE")
+
+
+class TestSanitizeAWSSecretKey:
+    """AWS Secret Access Key: 40-char base64 after common prefixes."""
+
+    def test_redacts_aws_secret_key(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        result = sanitizer.sanitize(text)
+        assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in result
+        assert "[REDACTED:aws-secret-key]" in result
+
+    def test_has_secrets_detects_aws_secret_key(self) -> None:
+        sanitizer = ContextSanitizer()
+        assert sanitizer.has_secrets(
+            "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+
+
+class TestSanitizePrivateKey:
+    """Private Key blocks: -----BEGIN ... PRIVATE KEY-----."""
+
+    def test_redacts_private_key_header(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALR..."
+        result = sanitizer.sanitize(text)
+        assert "-----BEGIN RSA PRIVATE KEY-----" not in result
+        assert "[REDACTED:private-key]" in result
+
+    def test_redacts_ec_private_key(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "-----BEGIN EC PRIVATE KEY-----"
+        result = sanitizer.sanitize(text)
+        assert "[REDACTED:private-key]" in result
+
+
+class TestSanitizeJWT:
+    """JWT tokens: eyJ... three base64url segments separated by dots."""
+
+    def test_redacts_jwt_token(self) -> None:
+        sanitizer = ContextSanitizer()
+        token = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0"
+            ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        )
+        text = f"Authorization: Bearer {token}"
+        result = sanitizer.sanitize(text)
+        assert token not in result
+        assert "[REDACTED:jwt]" in result
+
+
+class TestSanitizePassword:
+    """Generic password patterns: password = '...' or password = "..."."""
+
+    def test_redacts_password_single_quotes(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "password = 'super_secret_123'"
+        result = sanitizer.sanitize(text)
+        assert "super_secret_123" not in result
+        assert "[REDACTED:password]" in result
+
+    def test_redacts_password_double_quotes(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = 'password = "my-database-pw!"'
+        result = sanitizer.sanitize(text)
+        assert "my-database-pw!" not in result
+        assert "[REDACTED:password]" in result
+
+    def test_redacts_password_no_spaces(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "password='compact_secret'"
+        result = sanitizer.sanitize(text)
+        assert "compact_secret" not in result
+        assert "[REDACTED:password]" in result
+
+
+class TestSanitizeGitHubToken:
+    """GitHub tokens: ghp_ or ghs_ followed by 36+ alphanumeric chars."""
+
+    def test_redacts_github_pat(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+        result = sanitizer.sanitize(text)
+        assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl" not in result
+        assert "[REDACTED:github-token]" in result
+
+    def test_redacts_github_server_token(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "token: ghs_1234567890abcdefghijklmnopqrstuvwxyz"
+        result = sanitizer.sanitize(text)
+        assert "ghs_1234567890abcdefghijklmnopqrstuvwxyz" not in result
+        assert "[REDACTED:github-token]" in result
+
+
+class TestCleanTextPassthrough:
+    """Clean text without secrets should pass through unchanged."""
+
+    def test_clean_text_unchanged(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "This is a normal log message with no secrets."
+        assert sanitizer.sanitize(text) == text
+
+    def test_has_secrets_returns_false_for_clean_text(self) -> None:
+        sanitizer = ContextSanitizer()
+        assert not sanitizer.has_secrets("Just some regular code: x = 42")
+
+    def test_code_with_password_word_but_no_value(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "# Enter your password below"
+        assert sanitizer.sanitize(text) == text
+        assert not sanitizer.has_secrets(text)
+
+
+class TestMultipleSecrets:
+    """Multiple secrets in one text should all be redacted."""
+
+    def test_redacts_multiple_different_secrets(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = (
+            "aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n"
+            "password = 'db_secret_pass'\n"
+            "GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl\n"
+        )
+        result = sanitizer.sanitize(text)
+        assert "[REDACTED:aws-access-key]" in result
+        assert "[REDACTED:password]" in result
+        assert "[REDACTED:github-token]" in result
+        assert "AKIAIOSFODNN7EXAMPLE" not in result
+        assert "db_secret_pass" not in result
+
+    def test_has_secrets_true_with_multiple(self) -> None:
+        sanitizer = ContextSanitizer()
+        text = "AKIAIOSFODNN7EXAMPLE and password = 'oops'"
+        assert sanitizer.has_secrets(text)


### PR DESCRIPTION
## Summary
- Add ContextSanitizer class for detecting and redacting secrets before LLM context
- Supports AWS keys, GitHub tokens, private keys, passwords, generic API keys/tokens
- Multiline PEM key redaction, word-boundary matching

Closes #27

## Test plan
- [x] 19 pytest cases passing