### PR TITLE
feat: ✨ implement CachedGitHubMCP with TTL caching

### DIFF
--- a/src/myxo/cached_github.py
+++ b/src/myxo/cached_github.py
@@ -1,0 +1,46 @@
+"""CachedGitHubMCP - TTL-based request caching for GitHub MCP."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+class CachedGitHubMCP:
+    """TTL-based cache to reduce GitHub API calls.
+
+    Stores values in a dict with timestamps. Expired entries are
+    returned as None (lazy expiration).
+    """
+
+    def __init__(self, ttl: int = 300) -> None:
+        """Initialize cache with TTL in seconds."""
+        self.ttl = ttl
+        self._cache: dict[str, tuple[float, Any]] = {}
+
+    def get(self, key: str) -> Any | None:
+        """Return cached value if present and not expired, else None."""
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        timestamp, value = entry
+        if time.monotonic() - timestamp > self.ttl:
+            del self._cache[key]
+            return None
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        """Store a value in the cache with the current timestamp."""
+        self._cache[key] = (time.monotonic(), value)
+
+    def invalidate(self, key: str) -> None:
+        """Remove a specific key from the cache."""
+        self._cache.pop(key, None)
+
+    def clear(self) -> None:
+        """Remove all entries from the cache."""
+        self._cache.clear()
+
+    def is_cached(self, key: str) -> bool:
+        """Return True if the key exists and has not expired."""
+        return self.get(key) is not None

--- a/src/myxo/cached_github.py
+++ b/src/myxo/cached_github.py
@@ -10,7 +10,8 @@ class CachedGitHubMCP:
     """TTL-based cache to reduce GitHub API calls.
 
     Stores values in a dict with timestamps. Expired entries are
-    returned as None (lazy expiration).
+    lazily evicted on the next :meth:`get` call and the caller-supplied
+    *default* (``None`` when omitted) is returned instead.
     """
 
     _MISSING = object()
@@ -23,7 +24,12 @@ class CachedGitHubMCP:
         self._cache: dict[str, tuple[float, Any]] = {}
 
     def get(self, key: str, default: Any = None) -> Any:
-        """Return cached value if present and not expired, else *default*."""
+        """Return cached value if present and not expired.
+
+        If the key is missing or its TTL has expired, return *default*
+        (``None`` when the argument is omitted).  Expired entries are
+        deleted from the internal store on access.
+        """
         entry = self._cache.get(key, self._MISSING)
         if entry is self._MISSING:
             return default

--- a/src/myxo/cached_github.py
+++ b/src/myxo/cached_github.py
@@ -13,20 +13,24 @@ class CachedGitHubMCP:
     returned as None (lazy expiration).
     """
 
+    _MISSING = object()
+
     def __init__(self, ttl: int = 300) -> None:
         """Initialize cache with TTL in seconds."""
+        if ttl <= 0:
+            raise ValueError(f"ttl must be positive, got {ttl}")
         self.ttl = ttl
         self._cache: dict[str, tuple[float, Any]] = {}
 
-    def get(self, key: str) -> Any | None:
-        """Return cached value if present and not expired, else None."""
-        entry = self._cache.get(key)
-        if entry is None:
-            return None
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return cached value if present and not expired, else *default*."""
+        entry = self._cache.get(key, self._MISSING)
+        if entry is self._MISSING:
+            return default
         timestamp, value = entry
         if time.monotonic() - timestamp > self.ttl:
             del self._cache[key]
-            return None
+            return default
         return value
 
     def set(self, key: str, value: Any) -> None:
@@ -43,4 +47,4 @@ class CachedGitHubMCP:
 
     def is_cached(self, key: str) -> bool:
         """Return True if the key exists and has not expired."""
-        return self.get(key) is not None
+        return self.get(key, self._MISSING) is not self._MISSING

--- a/tests/test_cached_github.py
+++ b/tests/test_cached_github.py
@@ -1,126 +1,169 @@
 """Tests for CachedGitHubMCP."""
 
-import time
+from __future__ import annotations
+
+from unittest.mock import patch
 
 import pytest
 
 from myxo.cached_github import CachedGitHubMCP
 
 
-class TestCachedGitHubMCPInit:
-    """Test initialization."""
-
-    def test_default_ttl(self):
-        cache = CachedGitHubMCP()
-        assert cache.ttl == 300
-
-    def test_custom_ttl(self):
-        cache = CachedGitHubMCP(ttl=60)
-        assert cache.ttl == 60
+# --- init ---
 
 
-class TestCachedGitHubMCPSetAndGet:
-    """Test set and get operations."""
-
-    def test_get_returns_none_for_missing_key(self):
-        cache = CachedGitHubMCP()
-        assert cache.get("nonexistent") is None
-
-    def test_set_and_get_value(self):
-        cache = CachedGitHubMCP()
-        cache.set("key1", "value1")
-        assert cache.get("key1") == "value1"
-
-    def test_set_and_get_various_types(self):
-        cache = CachedGitHubMCP()
-        cache.set("str", "hello")
-        cache.set("int", 42)
-        cache.set("list", [1, 2, 3])
-        cache.set("dict", {"a": 1})
-        assert cache.get("str") == "hello"
-        assert cache.get("int") == 42
-        assert cache.get("list") == [1, 2, 3]
-        assert cache.get("dict") == {"a": 1}
-
-    def test_set_overwrites_existing_value(self):
-        cache = CachedGitHubMCP()
-        cache.set("key", "old")
-        cache.set("key", "new")
-        assert cache.get("key") == "new"
+def test_default_ttl():
+    cache = CachedGitHubMCP()
+    assert cache.ttl == 300
 
 
-class TestCachedGitHubMCPTTL:
-    """Test TTL expiration."""
+def test_custom_ttl():
+    cache = CachedGitHubMCP(ttl=60)
+    assert cache.ttl == 60
 
-    def test_get_returns_none_after_ttl_expired(self):
-        cache = CachedGitHubMCP(ttl=1)
+
+def test_ttl_zero_raises_value_error():
+    with pytest.raises(ValueError, match="ttl must be positive"):
+        CachedGitHubMCP(ttl=0)
+
+
+def test_ttl_negative_raises_value_error():
+    with pytest.raises(ValueError, match="ttl must be positive"):
+        CachedGitHubMCP(ttl=-10)
+
+
+# --- set / get ---
+
+
+def test_get_returns_none_for_missing_key():
+    cache = CachedGitHubMCP()
+    assert cache.get("nonexistent") is None
+
+
+def test_set_and_get_value():
+    cache = CachedGitHubMCP()
+    cache.set("key1", "value1")
+    assert cache.get("key1") == "value1"
+
+
+def test_set_and_get_various_types():
+    cache = CachedGitHubMCP()
+    cache.set("str", "hello")
+    cache.set("int", 42)
+    cache.set("list", [1, 2, 3])
+    cache.set("dict", {"a": 1})
+    assert cache.get("str") == "hello"
+    assert cache.get("int") == 42
+    assert cache.get("list") == [1, 2, 3]
+    assert cache.get("dict") == {"a": 1}
+
+
+def test_set_overwrites_existing_value():
+    cache = CachedGitHubMCP()
+    cache.set("key", "old")
+    cache.set("key", "new")
+    assert cache.get("key") == "new"
+
+
+def test_set_and_get_none_value():
+    """None can be stored and retrieved without being confused with 'missing'."""
+    cache = CachedGitHubMCP()
+    cache.set("key", None)
+    assert cache.get("key") is None
+    assert cache.is_cached("key") is True
+
+
+# --- TTL expiration (mocked clock) ---
+
+
+def test_get_returns_none_after_ttl_expired():
+    with patch("myxo.cached_github.time.monotonic") as mock_mono:
+        mock_mono.return_value = 1000.0
+        cache = CachedGitHubMCP(ttl=10)
         cache.set("key", "value")
         assert cache.get("key") == "value"
-        time.sleep(1.1)
+
+        mock_mono.return_value = 1010.1
         assert cache.get("key") is None
 
-    def test_is_cached_returns_false_after_ttl_expired(self):
-        cache = CachedGitHubMCP(ttl=1)
-        cache.set("key", "value")
-        assert cache.is_cached("key") is True
-        time.sleep(1.1)
-        assert cache.is_cached("key") is False
 
-
-class TestCachedGitHubMCPInvalidate:
-    """Test invalidation."""
-
-    def test_invalidate_removes_key(self):
-        cache = CachedGitHubMCP()
-        cache.set("key", "value")
-        cache.invalidate("key")
-        assert cache.get("key") is None
-
-    def test_invalidate_nonexistent_key_does_not_raise(self):
-        cache = CachedGitHubMCP()
-        cache.invalidate("nonexistent")  # should not raise
-
-
-class TestCachedGitHubMCPClear:
-    """Test clear operation."""
-
-    def test_clear_removes_all_keys(self):
-        cache = CachedGitHubMCP()
-        cache.set("a", 1)
-        cache.set("b", 2)
-        cache.set("c", 3)
-        cache.clear()
-        assert cache.get("a") is None
-        assert cache.get("b") is None
-        assert cache.get("c") is None
-
-
-class TestCachedGitHubMCPIsCached:
-    """Test is_cached method."""
-
-    def test_is_cached_returns_false_for_missing_key(self):
-        cache = CachedGitHubMCP()
-        assert cache.is_cached("nonexistent") is False
-
-    def test_is_cached_returns_true_for_existing_key(self):
-        cache = CachedGitHubMCP()
+def test_is_cached_returns_false_after_ttl_expired():
+    with patch("myxo.cached_github.time.monotonic") as mock_mono:
+        mock_mono.return_value = 1000.0
+        cache = CachedGitHubMCP(ttl=10)
         cache.set("key", "value")
         assert cache.is_cached("key") is True
 
-    def test_is_cached_returns_false_after_invalidation(self):
-        cache = CachedGitHubMCP()
-        cache.set("key", "value")
-        cache.invalidate("key")
+        mock_mono.return_value = 1010.1
         assert cache.is_cached("key") is False
 
 
-class TestCachedGitHubMCPCacheHit:
-    """Test that cache hit avoids redundant calls."""
+def test_value_still_valid_just_before_ttl():
+    with patch("myxo.cached_github.time.monotonic") as mock_mono:
+        mock_mono.return_value = 1000.0
+        cache = CachedGitHubMCP(ttl=10)
+        cache.set("key", "value")
 
-    def test_cache_hit_returns_same_object(self):
-        cache = CachedGitHubMCP()
-        data = {"repos": ["a", "b"]}
-        cache.set("repos", data)
-        # Multiple gets should return the cached value
-        assert cache.get("repos") is data
-        assert cache.get("repos") is data
+        mock_mono.return_value = 1009.9
+        assert cache.get("key") == "value"
+
+
+# --- invalidate ---
+
+
+def test_invalidate_removes_key():
+    cache = CachedGitHubMCP()
+    cache.set("key", "value")
+    cache.invalidate("key")
+    assert cache.get("key") is None
+
+
+def test_invalidate_nonexistent_key_does_not_raise():
+    cache = CachedGitHubMCP()
+    cache.invalidate("nonexistent")  # should not raise
+
+
+# --- clear ---
+
+
+def test_clear_removes_all_keys():
+    cache = CachedGitHubMCP()
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.set("c", 3)
+    cache.clear()
+    assert cache.get("a") is None
+    assert cache.get("b") is None
+    assert cache.get("c") is None
+
+
+# --- is_cached ---
+
+
+def test_is_cached_returns_false_for_missing_key():
+    cache = CachedGitHubMCP()
+    assert cache.is_cached("nonexistent") is False
+
+
+def test_is_cached_returns_true_for_existing_key():
+    cache = CachedGitHubMCP()
+    cache.set("key", "value")
+    assert cache.is_cached("key") is True
+
+
+def test_is_cached_returns_false_after_invalidation():
+    cache = CachedGitHubMCP()
+    cache.set("key", "value")
+    cache.invalidate("key")
+    assert cache.is_cached("key") is False
+
+
+# --- cache hit ---
+
+
+def test_cache_hit_returns_same_object():
+    cache = CachedGitHubMCP()
+    data = {"repos": ["a", "b"]}
+    cache.set("repos", data)
+    assert cache.get("repos") is data
+    assert cache.get("repos") is data

--- a/tests/test_cached_github.py
+++ b/tests/test_cached_github.py
@@ -1,0 +1,126 @@
+"""Tests for CachedGitHubMCP."""
+
+import time
+
+import pytest
+
+from myxo.cached_github import CachedGitHubMCP
+
+
+class TestCachedGitHubMCPInit:
+    """Test initialization."""
+
+    def test_default_ttl(self):
+        cache = CachedGitHubMCP()
+        assert cache.ttl == 300
+
+    def test_custom_ttl(self):
+        cache = CachedGitHubMCP(ttl=60)
+        assert cache.ttl == 60
+
+
+class TestCachedGitHubMCPSetAndGet:
+    """Test set and get operations."""
+
+    def test_get_returns_none_for_missing_key(self):
+        cache = CachedGitHubMCP()
+        assert cache.get("nonexistent") is None
+
+    def test_set_and_get_value(self):
+        cache = CachedGitHubMCP()
+        cache.set("key1", "value1")
+        assert cache.get("key1") == "value1"
+
+    def test_set_and_get_various_types(self):
+        cache = CachedGitHubMCP()
+        cache.set("str", "hello")
+        cache.set("int", 42)
+        cache.set("list", [1, 2, 3])
+        cache.set("dict", {"a": 1})
+        assert cache.get("str") == "hello"
+        assert cache.get("int") == 42
+        assert cache.get("list") == [1, 2, 3]
+        assert cache.get("dict") == {"a": 1}
+
+    def test_set_overwrites_existing_value(self):
+        cache = CachedGitHubMCP()
+        cache.set("key", "old")
+        cache.set("key", "new")
+        assert cache.get("key") == "new"
+
+
+class TestCachedGitHubMCPTTL:
+    """Test TTL expiration."""
+
+    def test_get_returns_none_after_ttl_expired(self):
+        cache = CachedGitHubMCP(ttl=1)
+        cache.set("key", "value")
+        assert cache.get("key") == "value"
+        time.sleep(1.1)
+        assert cache.get("key") is None
+
+    def test_is_cached_returns_false_after_ttl_expired(self):
+        cache = CachedGitHubMCP(ttl=1)
+        cache.set("key", "value")
+        assert cache.is_cached("key") is True
+        time.sleep(1.1)
+        assert cache.is_cached("key") is False
+
+
+class TestCachedGitHubMCPInvalidate:
+    """Test invalidation."""
+
+    def test_invalidate_removes_key(self):
+        cache = CachedGitHubMCP()
+        cache.set("key", "value")
+        cache.invalidate("key")
+        assert cache.get("key") is None
+
+    def test_invalidate_nonexistent_key_does_not_raise(self):
+        cache = CachedGitHubMCP()
+        cache.invalidate("nonexistent")  # should not raise
+
+
+class TestCachedGitHubMCPClear:
+    """Test clear operation."""
+
+    def test_clear_removes_all_keys(self):
+        cache = CachedGitHubMCP()
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.set("c", 3)
+        cache.clear()
+        assert cache.get("a") is None
+        assert cache.get("b") is None
+        assert cache.get("c") is None
+
+
+class TestCachedGitHubMCPIsCached:
+    """Test is_cached method."""
+
+    def test_is_cached_returns_false_for_missing_key(self):
+        cache = CachedGitHubMCP()
+        assert cache.is_cached("nonexistent") is False
+
+    def test_is_cached_returns_true_for_existing_key(self):
+        cache = CachedGitHubMCP()
+        cache.set("key", "value")
+        assert cache.is_cached("key") is True
+
+    def test_is_cached_returns_false_after_invalidation(self):
+        cache = CachedGitHubMCP()
+        cache.set("key", "value")
+        cache.invalidate("key")
+        assert cache.is_cached("key") is False
+
+
+class TestCachedGitHubMCPCacheHit:
+    """Test that cache hit avoids redundant calls."""
+
+    def test_cache_hit_returns_same_object(self):
+        cache = CachedGitHubMCP()
+        data = {"repos": ["a", "b"]}
+        cache.set("repos", data)
+        # Multiple gets should return the cached value
+        assert cache.get("repos") is data
+        assert cache.get("repos") is data


### PR DESCRIPTION
## Summary
- Add CachedGitHubMCP class with TTL-based in-memory caching
- Sentinel pattern for correct None value handling
- TTL validation, clock-mockable design

Closes #45

## Test plan
- [x] 19 pytest cases passing