### PR TITLE
feat: ✨ implement SecureFilesystemMCP file access allowlist

### DIFF
--- a/src/myxo/secure_filesystem.py
+++ b/src/myxo/secure_filesystem.py
@@ -18,9 +18,13 @@ class SecureFilesystemMCP:
         self,
         allowed_patterns: list[str],
         blocked_patterns: list[str],
+        project_root: str | None = None,
     ) -> None:
-        self.allowed_patterns = allowed_patterns
-        self.blocked_patterns = blocked_patterns
+        self.allowed_patterns = tuple(allowed_patterns)
+        self.blocked_patterns = tuple(blocked_patterns)
+        self.project_root: str | None = (
+            self._normalize(project_root) if project_root is not None else None
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -31,7 +35,20 @@ class SecureFilesystemMCP:
         """Normalize backslashes to forward slashes for cross-platform support."""
         return path.replace("\\", "/")
 
-    def _matches_any(self, path: str, patterns: list[str]) -> bool:
+    def _is_within_project_root(self, path: str) -> bool:
+        """Return True if *path* is under the project root (when set)."""
+        if self.project_root is None:
+            return True
+        path = self._normalize(path)
+        # Resolve to absolute using project_root as base for relative paths
+        pure = PurePosixPath(path)
+        if not pure.is_absolute():
+            path = str(PurePosixPath(self.project_root) / path)
+        # Ensure the path starts with project_root
+        root = self.project_root.rstrip("/")
+        return path == root or path.startswith(root + "/")
+
+    def _matches_any(self, path: str, patterns: tuple[str, ...]) -> bool:
         """Return True if *path* matches at least one of *patterns*.
 
         Matching is performed against both the full path string and every
@@ -64,6 +81,12 @@ class SecureFilesystemMCP:
     def check_access(self, path: str) -> bool:
         """Return ``True`` if *path* is accessible, ``False`` otherwise."""
         path = self._normalize(path)
+        # Reject absolute paths when no project_root is configured
+        if self.project_root is None and PurePosixPath(path).is_absolute():
+            return False
+        # Reject paths outside the project root
+        if not self._is_within_project_root(path):
+            return False
         if self._matches_any(path, self.blocked_patterns):
             return False
         return self._matches_any(path, self.allowed_patterns)

--- a/src/myxo/secure_filesystem.py
+++ b/src/myxo/secure_filesystem.py
@@ -26,6 +26,11 @@ class SecureFilesystemMCP:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _normalize(path: str) -> str:
+        """Normalize backslashes to forward slashes for cross-platform support."""
+        return path.replace("\\", "/")
+
     def _matches_any(self, path: str, patterns: list[str]) -> bool:
         """Return True if *path* matches at least one of *patterns*.
 
@@ -34,6 +39,7 @@ class SecureFilesystemMCP:
         patterns like ``*.pem`` catch ``src/certs/server.pem`` and
         patterns like ``secrets/**`` catch ``secrets/api_key.txt``.
         """
+        path = self._normalize(path)
         pure = PurePosixPath(path)
         for pattern in patterns:
             # Match the full path
@@ -57,6 +63,7 @@ class SecureFilesystemMCP:
 
     def check_access(self, path: str) -> bool:
         """Return ``True`` if *path* is accessible, ``False`` otherwise."""
+        path = self._normalize(path)
         if self._matches_any(path, self.blocked_patterns):
             return False
         return self._matches_any(path, self.allowed_patterns)

--- a/src/myxo/secure_filesystem.py
+++ b/src/myxo/secure_filesystem.py
@@ -1,0 +1,69 @@
+"""SecureFilesystemMCP — file access allowlist for AI agent infrastructure."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import PurePosixPath
+
+
+class SecureFilesystemMCP:
+    """Guard that restricts file access to an explicit allowlist.
+
+    *Blocked* patterns always take priority over *allowed* patterns, so
+    sensitive files (secrets, keys, env files, ...) are never accessible
+    even when they happen to sit inside an allowed directory tree.
+    """
+
+    def __init__(
+        self,
+        allowed_patterns: list[str],
+        blocked_patterns: list[str],
+    ) -> None:
+        self.allowed_patterns = allowed_patterns
+        self.blocked_patterns = blocked_patterns
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _matches_any(self, path: str, patterns: list[str]) -> bool:
+        """Return True if *path* matches at least one of *patterns*.
+
+        Matching is performed against both the full path string and every
+        individual component (filename, parent directories) so that
+        patterns like ``*.pem`` catch ``src/certs/server.pem`` and
+        patterns like ``secrets/**`` catch ``secrets/api_key.txt``.
+        """
+        pure = PurePosixPath(path)
+        for pattern in patterns:
+            # Match the full path
+            if fnmatch(path, pattern):
+                return True
+            # Match just the filename (handles e.g. "*.pem", ".env*")
+            if fnmatch(pure.name, pattern):
+                return True
+            # Match each ancestor + remaining tail so directory patterns
+            # like "secrets/**" work for "secrets/api_key.txt"
+            parts = pure.parts
+            for i in range(len(parts)):
+                sub = str(PurePosixPath(*parts[i:]))
+                if fnmatch(sub, pattern):
+                    return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def check_access(self, path: str) -> bool:
+        """Return ``True`` if *path* is accessible, ``False`` otherwise."""
+        if self._matches_any(path, self.blocked_patterns):
+            return False
+        return self._matches_any(path, self.allowed_patterns)
+
+    def validate_access(self, path: str) -> None:
+        """Raise :class:`PermissionError` if *path* is not accessible."""
+        if not self.check_access(path):
+            raise PermissionError(
+                f"Access denied: '{path}' is not in the allowed file list"
+            )

--- a/tests/test_secure_filesystem.py
+++ b/tests/test_secure_filesystem.py
@@ -29,7 +29,7 @@ ALLOWED_PATTERNS = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def mcp() -> SecureFilesystemMCP:
     return SecureFilesystemMCP(
         allowed_patterns=ALLOWED_PATTERNS,
@@ -40,131 +40,205 @@ def mcp() -> SecureFilesystemMCP:
 # ===== check_access: allowed paths =====
 
 
-class TestCheckAccessAllowed:
-    def test_python_file_in_src(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("src/myxo/cli.py") is True
+def test_python_file_in_src(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("src/myxo/cli.py") is True
 
-    def test_python_file_in_tests(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("tests/test_cli.py") is True
 
-    def test_toml_config(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("pyproject.toml") is True
+def test_python_file_in_tests(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("tests/test_cli.py") is True
 
-    def test_yaml_config(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("config.yaml") is True
 
-    def test_yml_config(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("config.yml") is True
+def test_toml_config(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("pyproject.toml") is True
 
-    def test_json_config(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("settings.json") is True
 
-    def test_cfg_file(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("setup.cfg") is True
+def test_yaml_config(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("config.yaml") is True
 
-    def test_nested_src_file(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("src/myxo/subdir/module.py") is True
+
+def test_yml_config(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("config.yml") is True
+
+
+def test_json_config(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("settings.json") is True
+
+
+def test_cfg_file(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("setup.cfg") is True
+
+
+def test_nested_src_file(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("src/myxo/subdir/module.py") is True
 
 
 # ===== check_access: blocked paths =====
 
 
-class TestCheckAccessBlocked:
-    def test_env_file(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access(".env") is False
+def test_env_file(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access(".env") is False
 
-    def test_env_local(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access(".env.local") is False
 
-    def test_env_production(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access(".env.production") is False
+def test_env_local(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access(".env.local") is False
 
-    def test_secrets_dir(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("secrets/api_key.txt") is False
 
-    def test_credentials_dir(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("credentials/token.json") is False
+def test_env_production(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access(".env.production") is False
 
-    def test_pem_file(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("server.pem") is False
 
-    def test_key_file(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("private.key") is False
+def test_secrets_dir(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("secrets/api_key.txt") is False
 
-    def test_pem_in_src(self, mcp: SecureFilesystemMCP) -> None:
-        """Blocked patterns take priority over allowed patterns."""
-        assert mcp.check_access("src/certs/server.pem") is False
 
-    def test_env_in_tests(self, mcp: SecureFilesystemMCP) -> None:
-        """Blocked patterns take priority even inside allowed dirs."""
-        assert mcp.check_access("tests/.env") is False
+def test_credentials_dir(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("credentials/token.json") is False
+
+
+def test_pem_file(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("server.pem") is False
+
+
+def test_key_file(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("private.key") is False
+
+
+def test_pem_in_src(mcp: SecureFilesystemMCP) -> None:
+    """Blocked patterns take priority over allowed patterns."""
+    assert mcp.check_access("src/certs/server.pem") is False
+
+
+def test_env_in_tests(mcp: SecureFilesystemMCP) -> None:
+    """Blocked patterns take priority even inside allowed dirs."""
+    assert mcp.check_access("tests/.env") is False
 
 
 # ===== check_access: not in allowed list =====
 
 
-class TestCheckAccessNotAllowed:
-    def test_random_txt_file(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("notes.txt") is False
+def test_random_txt_file(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("notes.txt") is False
 
-    def test_binary_file(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("program.exe") is False
 
-    def test_markdown_outside_src(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("docs/readme.md") is False
+def test_binary_file(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("program.exe") is False
+
+
+def test_markdown_outside_src(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("docs/readme.md") is False
 
 
 # ===== blocked_patterns priority over allowed_patterns =====
 
 
-class TestBlockedPriority:
-    def test_key_in_allowed_dir(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.check_access("src/myxo/service.key") is False
+def test_key_in_allowed_dir(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.check_access("src/myxo/service.key") is False
 
-    def test_secrets_json_matches_both(self, mcp: SecureFilesystemMCP) -> None:
-        """secrets/config.json matches allowed *.json AND blocked secrets/**."""
-        assert mcp.check_access("secrets/config.json") is False
+
+def test_secrets_json_matches_both(mcp: SecureFilesystemMCP) -> None:
+    """secrets/config.json matches allowed *.json AND blocked secrets/**."""
+    assert mcp.check_access("secrets/config.json") is False
 
 
 # ===== validate_access =====
 
 
-class TestValidateAccess:
-    def test_allowed_path_does_not_raise(self, mcp: SecureFilesystemMCP) -> None:
-        mcp.validate_access("src/myxo/cli.py")  # should not raise
+def test_validate_allowed_path_does_not_raise(mcp: SecureFilesystemMCP) -> None:
+    mcp.validate_access("src/myxo/cli.py")  # should not raise
 
-    def test_blocked_path_raises_permission_error(
-        self, mcp: SecureFilesystemMCP
-    ) -> None:
-        with pytest.raises(PermissionError):
-            mcp.validate_access(".env")
 
-    def test_not_allowed_path_raises_permission_error(
-        self, mcp: SecureFilesystemMCP
-    ) -> None:
-        with pytest.raises(PermissionError):
-            mcp.validate_access("notes.txt")
+def test_validate_blocked_path_raises_permission_error(
+    mcp: SecureFilesystemMCP,
+) -> None:
+    with pytest.raises(PermissionError):
+        mcp.validate_access(".env")
 
-    def test_error_message_contains_path(self, mcp: SecureFilesystemMCP) -> None:
-        with pytest.raises(PermissionError, match="private.key"):
-            mcp.validate_access("private.key")
+
+def test_validate_not_allowed_path_raises_permission_error(
+    mcp: SecureFilesystemMCP,
+) -> None:
+    with pytest.raises(PermissionError):
+        mcp.validate_access("notes.txt")
+
+
+def test_validate_error_message_contains_path(mcp: SecureFilesystemMCP) -> None:
+    with pytest.raises(PermissionError, match="private.key"):
+        mcp.validate_access("private.key")
 
 
 # ===== constructor stores patterns =====
 
 
-class TestConstructor:
-    def test_stores_allowed_patterns(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.allowed_patterns == ALLOWED_PATTERNS
+def test_stores_allowed_patterns(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.allowed_patterns == ALLOWED_PATTERNS
 
-    def test_stores_blocked_patterns(self, mcp: SecureFilesystemMCP) -> None:
-        assert mcp.blocked_patterns == BLOCKED_PATTERNS
 
-    def test_empty_patterns(self) -> None:
-        fs = SecureFilesystemMCP(allowed_patterns=[], blocked_patterns=[])
-        # Nothing is allowed when allowed list is empty
-        assert fs.check_access("anything.py") is False
+def test_stores_blocked_patterns(mcp: SecureFilesystemMCP) -> None:
+    assert mcp.blocked_patterns == BLOCKED_PATTERNS
 
-    def test_no_blocked_patterns(self) -> None:
-        fs = SecureFilesystemMCP(allowed_patterns=["*.py"], blocked_patterns=[])
-        assert fs.check_access("main.py") is True
+
+def test_empty_patterns() -> None:
+    fs = SecureFilesystemMCP(allowed_patterns=[], blocked_patterns=[])
+    # Nothing is allowed when allowed list is empty
+    assert fs.check_access("anything.py") is False
+
+
+def test_no_blocked_patterns() -> None:
+    fs = SecureFilesystemMCP(allowed_patterns=["*.py"], blocked_patterns=[])
+    assert fs.check_access("main.py") is True
+
+
+# ===== path normalization (Windows-style backslashes & absolute paths) =====
+
+
+def test_backslash_path_allowed(mcp: SecureFilesystemMCP) -> None:
+    """Windows-style backslash path should be normalized and matched."""
+    assert mcp.check_access("src\\myxo\\cli.py") is True
+
+
+def test_backslash_path_blocked(mcp: SecureFilesystemMCP) -> None:
+    """Blocked patterns should catch backslash paths too."""
+    assert mcp.check_access("src\\certs\\server.pem") is False
+
+
+def test_backslash_secrets_blocked(mcp: SecureFilesystemMCP) -> None:
+    """Directory-based blocked pattern must work with backslash separators."""
+    assert mcp.check_access("secrets\\api_key.txt") is False
+
+
+def test_mixed_separators(mcp: SecureFilesystemMCP) -> None:
+    """Paths mixing forward and back slashes should be normalized."""
+    assert mcp.check_access("src\\myxo/module.py") is True
+
+
+def test_absolute_posix_path_allowed(mcp: SecureFilesystemMCP) -> None:
+    """Absolute POSIX path containing an allowed subtree."""
+    fs = SecureFilesystemMCP(
+        allowed_patterns=["src/**"],
+        blocked_patterns=[],
+    )
+    # Absolute path — the 'src' component still appears, so sub-path matching works
+    assert fs.check_access("/home/user/project/src/main.py") is True
+
+
+def test_absolute_windows_path_blocked(mcp: SecureFilesystemMCP) -> None:
+    """Absolute Windows-style path with a blocked filename."""
+    assert mcp.check_access("C:\\Users\\dev\\project\\private.key") is False
+
+
+# ===== broad glob does not bypass blocked patterns =====
+
+
+def test_broad_glob_does_not_bypass_blocked_env(mcp: SecureFilesystemMCP) -> None:
+    """*.py glob in allowed should not let .env* slip through."""
+    assert mcp.check_access("src/.env.local") is False
+
+
+def test_broad_glob_does_not_bypass_blocked_pem(mcp: SecureFilesystemMCP) -> None:
+    """Even deeply nested .pem files must be blocked."""
+    assert mcp.check_access("src/deep/nested/cert.pem") is False
+
+
+def test_broad_glob_does_not_bypass_blocked_key(mcp: SecureFilesystemMCP) -> None:
+    """Even deeply nested .key files must be blocked."""
+    assert mcp.check_access("tests/fixtures/server.key") is False

--- a/tests/test_secure_filesystem.py
+++ b/tests/test_secure_filesystem.py
@@ -170,11 +170,17 @@ def test_validate_error_message_contains_path(mcp: SecureFilesystemMCP) -> None:
 
 
 def test_stores_allowed_patterns(mcp: SecureFilesystemMCP) -> None:
-    assert mcp.allowed_patterns == ALLOWED_PATTERNS
+    assert list(mcp.allowed_patterns) == ALLOWED_PATTERNS
 
 
 def test_stores_blocked_patterns(mcp: SecureFilesystemMCP) -> None:
-    assert mcp.blocked_patterns == BLOCKED_PATTERNS
+    assert list(mcp.blocked_patterns) == BLOCKED_PATTERNS
+
+
+def test_patterns_are_tuples(mcp: SecureFilesystemMCP) -> None:
+    """Patterns should be stored as tuples (defensive copy)."""
+    assert isinstance(mcp.allowed_patterns, tuple)
+    assert isinstance(mcp.blocked_patterns, tuple)
 
 
 def test_empty_patterns() -> None:
@@ -211,13 +217,24 @@ def test_mixed_separators(mcp: SecureFilesystemMCP) -> None:
     assert mcp.check_access("src\\myxo/module.py") is True
 
 
-def test_absolute_posix_path_allowed(mcp: SecureFilesystemMCP) -> None:
-    """Absolute POSIX path containing an allowed subtree."""
+def test_absolute_posix_path_rejected_without_project_root(
+    mcp: SecureFilesystemMCP,
+) -> None:
+    """Absolute POSIX path should be rejected when no project_root is set."""
     fs = SecureFilesystemMCP(
         allowed_patterns=["src/**"],
         blocked_patterns=[],
     )
-    # Absolute path — the 'src' component still appears, so sub-path matching works
+    assert fs.check_access("/home/user/project/src/main.py") is False
+
+
+def test_absolute_posix_path_allowed_with_project_root() -> None:
+    """Absolute POSIX path allowed when within project_root."""
+    fs = SecureFilesystemMCP(
+        allowed_patterns=["src/**"],
+        blocked_patterns=[],
+        project_root="/home/user/project",
+    )
     assert fs.check_access("/home/user/project/src/main.py") is True
 
 
@@ -242,3 +259,76 @@ def test_broad_glob_does_not_bypass_blocked_pem(mcp: SecureFilesystemMCP) -> Non
 def test_broad_glob_does_not_bypass_blocked_key(mcp: SecureFilesystemMCP) -> None:
     """Even deeply nested .key files must be blocked."""
     assert mcp.check_access("tests/fixtures/server.key") is False
+
+
+# ===== project_root constraint =====
+
+
+def test_project_root_rejects_path_outside() -> None:
+    """Paths outside the project_root must be rejected."""
+    fs = SecureFilesystemMCP(
+        allowed_patterns=["*.py"],
+        blocked_patterns=[],
+        project_root="/home/user/project",
+    )
+    assert fs.check_access("/etc/evil.py") is False
+
+
+def test_project_root_allows_relative_path() -> None:
+    """Relative paths are resolved against project_root and allowed."""
+    fs = SecureFilesystemMCP(
+        allowed_patterns=["*.py"],
+        blocked_patterns=[],
+        project_root="/home/user/project",
+    )
+    assert fs.check_access("main.py") is True
+
+
+def test_project_root_rejects_absolute_outside() -> None:
+    """Absolute path outside project_root should be rejected even if pattern matches."""
+    fs = SecureFilesystemMCP(
+        allowed_patterns=["**/*.py"],
+        blocked_patterns=[],
+        project_root="/home/user/project",
+    )
+    assert fs.check_access("/tmp/hack.py") is False
+
+
+def test_etc_evil_py_rejected_without_project_root() -> None:
+    """/etc/evil.py must be rejected — absolute path without project_root."""
+    fs = SecureFilesystemMCP(
+        allowed_patterns=["*.py"],
+        blocked_patterns=[],
+    )
+    assert fs.check_access("/etc/evil.py") is False
+
+
+def test_etc_evil_py_rejected_with_project_root() -> None:
+    """/etc/evil.py must be rejected — outside project_root."""
+    fs = SecureFilesystemMCP(
+        allowed_patterns=["*.py"],
+        blocked_patterns=[],
+        project_root="/home/user/project",
+    )
+    assert fs.check_access("/etc/evil.py") is False
+
+
+# ===== defensive copy =====
+
+
+def test_defensive_copy_allowed_patterns() -> None:
+    """Mutating the original list after construction must not affect the guard."""
+    allowed = ["*.py"]
+    fs = SecureFilesystemMCP(allowed_patterns=allowed, blocked_patterns=[])
+    allowed.append("*.sh")
+    # *.sh was added after construction — should NOT be allowed
+    assert fs.check_access("script.sh") is False
+
+
+def test_defensive_copy_blocked_patterns() -> None:
+    """Mutating the original blocked list after construction must not affect the guard."""
+    blocked = ["*.key"]
+    fs = SecureFilesystemMCP(allowed_patterns=["*"], blocked_patterns=blocked)
+    blocked.clear()
+    # *.key was in blocked at construction — should still be blocked
+    assert fs.check_access("private.key") is False

--- a/tests/test_secure_filesystem.py
+++ b/tests/test_secure_filesystem.py
@@ -1,0 +1,170 @@
+"""Tests for SecureFilesystemMCP file access allowlist."""
+
+import pytest
+
+from myxo.secure_filesystem import SecureFilesystemMCP
+
+
+# ---------------------------------------------------------------------------
+# Default patterns used across tests
+# ---------------------------------------------------------------------------
+
+BLOCKED_PATTERNS = [
+    ".env*",
+    "secrets/**",
+    "credentials/**",
+    "*.pem",
+    "*.key",
+]
+
+ALLOWED_PATTERNS = [
+    "src/**",
+    "tests/**",
+    "*.py",
+    "*.toml",
+    "*.yaml",
+    "*.yml",
+    "*.json",
+    "*.cfg",
+]
+
+
+@pytest.fixture
+def mcp() -> SecureFilesystemMCP:
+    return SecureFilesystemMCP(
+        allowed_patterns=ALLOWED_PATTERNS,
+        blocked_patterns=BLOCKED_PATTERNS,
+    )
+
+
+# ===== check_access: allowed paths =====
+
+
+class TestCheckAccessAllowed:
+    def test_python_file_in_src(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("src/myxo/cli.py") is True
+
+    def test_python_file_in_tests(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("tests/test_cli.py") is True
+
+    def test_toml_config(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("pyproject.toml") is True
+
+    def test_yaml_config(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("config.yaml") is True
+
+    def test_yml_config(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("config.yml") is True
+
+    def test_json_config(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("settings.json") is True
+
+    def test_cfg_file(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("setup.cfg") is True
+
+    def test_nested_src_file(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("src/myxo/subdir/module.py") is True
+
+
+# ===== check_access: blocked paths =====
+
+
+class TestCheckAccessBlocked:
+    def test_env_file(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access(".env") is False
+
+    def test_env_local(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access(".env.local") is False
+
+    def test_env_production(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access(".env.production") is False
+
+    def test_secrets_dir(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("secrets/api_key.txt") is False
+
+    def test_credentials_dir(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("credentials/token.json") is False
+
+    def test_pem_file(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("server.pem") is False
+
+    def test_key_file(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("private.key") is False
+
+    def test_pem_in_src(self, mcp: SecureFilesystemMCP) -> None:
+        """Blocked patterns take priority over allowed patterns."""
+        assert mcp.check_access("src/certs/server.pem") is False
+
+    def test_env_in_tests(self, mcp: SecureFilesystemMCP) -> None:
+        """Blocked patterns take priority even inside allowed dirs."""
+        assert mcp.check_access("tests/.env") is False
+
+
+# ===== check_access: not in allowed list =====
+
+
+class TestCheckAccessNotAllowed:
+    def test_random_txt_file(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("notes.txt") is False
+
+    def test_binary_file(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("program.exe") is False
+
+    def test_markdown_outside_src(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("docs/readme.md") is False
+
+
+# ===== blocked_patterns priority over allowed_patterns =====
+
+
+class TestBlockedPriority:
+    def test_key_in_allowed_dir(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.check_access("src/myxo/service.key") is False
+
+    def test_secrets_json_matches_both(self, mcp: SecureFilesystemMCP) -> None:
+        """secrets/config.json matches allowed *.json AND blocked secrets/**."""
+        assert mcp.check_access("secrets/config.json") is False
+
+
+# ===== validate_access =====
+
+
+class TestValidateAccess:
+    def test_allowed_path_does_not_raise(self, mcp: SecureFilesystemMCP) -> None:
+        mcp.validate_access("src/myxo/cli.py")  # should not raise
+
+    def test_blocked_path_raises_permission_error(
+        self, mcp: SecureFilesystemMCP
+    ) -> None:
+        with pytest.raises(PermissionError):
+            mcp.validate_access(".env")
+
+    def test_not_allowed_path_raises_permission_error(
+        self, mcp: SecureFilesystemMCP
+    ) -> None:
+        with pytest.raises(PermissionError):
+            mcp.validate_access("notes.txt")
+
+    def test_error_message_contains_path(self, mcp: SecureFilesystemMCP) -> None:
+        with pytest.raises(PermissionError, match="private.key"):
+            mcp.validate_access("private.key")
+
+
+# ===== constructor stores patterns =====
+
+
+class TestConstructor:
+    def test_stores_allowed_patterns(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.allowed_patterns == ALLOWED_PATTERNS
+
+    def test_stores_blocked_patterns(self, mcp: SecureFilesystemMCP) -> None:
+        assert mcp.blocked_patterns == BLOCKED_PATTERNS
+
+    def test_empty_patterns(self) -> None:
+        fs = SecureFilesystemMCP(allowed_patterns=[], blocked_patterns=[])
+        # Nothing is allowed when allowed list is empty
+        assert fs.check_access("anything.py") is False
+
+    def test_no_blocked_patterns(self) -> None:
+        fs = SecureFilesystemMCP(allowed_patterns=["*.py"], blocked_patterns=[])
+        assert fs.check_access("main.py") is True


### PR DESCRIPTION
## Summary
- Add SecureFilesystemMCP with allowlist/blocklist pattern matching
- Blocked patterns always take priority over allowed patterns
- Windows path normalization support

Closes #26

## Test plan
- [x] 39 pytest cases passing