### PR TITLE
feat: ✨ implement Claude prompt caching manager

### DIFF
--- a/src/myxo/prompt_cache.py
+++ b/src/myxo/prompt_cache.py
@@ -74,11 +74,7 @@ class PromptCacheManager:
             "cache_hits": self._cache_hits,
             "cache_misses": self._cache_misses,
             "total_requests": self._total_requests,
-            "hit_rate": (
-                self._cache_hits / self._total_requests
-                if self._total_requests > 0
-                else 0.0
-            ),
+            "hit_rate": (self._cache_hits / self._total_requests if self._total_requests > 0 else 0.0),
         }
 
     def _track(self, content: str) -> None:

--- a/src/myxo/prompt_cache.py
+++ b/src/myxo/prompt_cache.py
@@ -44,7 +44,9 @@ class PromptCacheManager:
         result = copy.deepcopy(messages)
 
         for msg in result:
-            content = msg["content"]
+            content = msg.get("content")
+            if content is None:
+                continue
 
             if isinstance(content, str):
                 if self.is_cacheable(content):
@@ -58,6 +60,8 @@ class PromptCacheManager:
                     ]
             elif isinstance(content, list):
                 for block in content:
+                    if not isinstance(block, dict):
+                        continue
                     if block.get("type") == "text" and self.is_cacheable(block.get("text", "")):
                         self._track(block["text"])
                         block["cache_control"] = {"type": "ephemeral"}

--- a/src/myxo/prompt_cache.py
+++ b/src/myxo/prompt_cache.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+from typing import Any
 
 
 class PromptCacheManager:
@@ -16,11 +17,18 @@ class PromptCacheManager:
     Args:
         cacheable_prefixes: List of content prefixes that identify immutable,
             cacheable content (e.g. ["Ship's Log", "Skills"]).
+        max_history: Maximum number of content hashes to track. When exceeded,
+            the set is cleared to prevent unbounded memory growth.
     """
 
-    def __init__(self, cacheable_prefixes: list[str]) -> None:
-        self.cacheable_prefixes = cacheable_prefixes
+    def __init__(
+        self,
+        cacheable_prefixes: list[str],
+        max_history: int = 10000,
+    ) -> None:
+        self.cacheable_prefixes = tuple(cacheable_prefixes)
         self._seen_hashes: set[str] = set()
+        self._max_history = max_history
         self._cache_hits = 0
         self._cache_misses = 0
         self._total_requests = 0
@@ -31,7 +39,7 @@ class PromptCacheManager:
             return False
         return any(content.startswith(prefix) for prefix in self.cacheable_prefixes)
 
-    def prepare_messages(self, messages: list[dict]) -> list[dict]:
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Return a copy of messages with cache_control added to cacheable content.
 
         String content that is cacheable is converted to the block format:
@@ -68,7 +76,7 @@ class PromptCacheManager:
 
         return result
 
-    def get_cache_stats(self) -> dict:
+    def get_cache_stats(self) -> dict[str, Any]:
         """Return cache statistics."""
         return {
             "cache_hits": self._cache_hits,
@@ -85,4 +93,6 @@ class PromptCacheManager:
             self._cache_hits += 1
         else:
             self._cache_misses += 1
+            if len(self._seen_hashes) >= self._max_history:
+                self._seen_hashes.clear()
             self._seen_hashes.add(content_hash)

--- a/src/myxo/prompt_cache.py
+++ b/src/myxo/prompt_cache.py
@@ -1,0 +1,88 @@
+"""Claude prompt caching manager.
+
+Adds cache_control markers to immutable content (e.g. Ship's Log, Skills)
+so that the Anthropic API can cache prompt prefixes and reduce costs by ~90%.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+
+
+class PromptCacheManager:
+    """Manages prompt caching by injecting cache_control into messages.
+
+    Args:
+        cacheable_prefixes: List of content prefixes that identify immutable,
+            cacheable content (e.g. ["Ship's Log", "Skills"]).
+    """
+
+    def __init__(self, cacheable_prefixes: list[str]) -> None:
+        self.cacheable_prefixes = cacheable_prefixes
+        self._seen_hashes: set[str] = set()
+        self._cache_hits = 0
+        self._cache_misses = 0
+        self._total_requests = 0
+
+    def is_cacheable(self, content: str) -> bool:
+        """Determine whether content is cacheable based on prefix matching."""
+        if not content:
+            return False
+        return any(content.startswith(prefix) for prefix in self.cacheable_prefixes)
+
+    def prepare_messages(self, messages: list[dict]) -> list[dict]:
+        """Return a copy of messages with cache_control added to cacheable content.
+
+        String content that is cacheable is converted to the block format:
+            [{"type": "text", "text": "...", "cache_control": {"type": "ephemeral"}}]
+
+        Block content (list of dicts) has cache_control added to each cacheable block.
+
+        Non-cacheable content is left unchanged.
+        """
+        result = copy.deepcopy(messages)
+
+        for msg in result:
+            content = msg["content"]
+
+            if isinstance(content, str):
+                if self.is_cacheable(content):
+                    self._track(content)
+                    msg["content"] = [
+                        {
+                            "type": "text",
+                            "text": content,
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ]
+            elif isinstance(content, list):
+                for block in content:
+                    if block.get("type") == "text" and self.is_cacheable(block.get("text", "")):
+                        self._track(block["text"])
+                        block["cache_control"] = {"type": "ephemeral"}
+
+        return result
+
+    def get_cache_stats(self) -> dict:
+        """Return cache statistics."""
+        return {
+            "cache_hits": self._cache_hits,
+            "cache_misses": self._cache_misses,
+            "total_requests": self._total_requests,
+            "hit_rate": (
+                self._cache_hits / self._total_requests
+                if self._total_requests > 0
+                else 0.0
+            ),
+        }
+
+    def _track(self, content: str) -> None:
+        """Track cache hit/miss based on content hash."""
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        self._total_requests += 1
+        if content_hash in self._seen_hashes:
+            self._cache_hits += 1
+        else:
+            self._cache_misses += 1
+            self._seen_hashes.add(content_hash)

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -9,12 +9,12 @@ from myxo.prompt_cache import PromptCacheManager
 
 def test_init_with_cacheable_prefixes():
     manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
-    assert manager.cacheable_prefixes == ["Ship's Log", "Skills"]
+    assert manager.cacheable_prefixes == ("Ship's Log", "Skills")
 
 
 def test_init_with_empty_prefixes():
     manager = PromptCacheManager(cacheable_prefixes=[])
-    assert manager.cacheable_prefixes == []
+    assert manager.cacheable_prefixes == ()
 
 
 def test_init_default_stats():

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1,0 +1,176 @@
+"""Tests for Claude prompt caching manager."""
+
+import pytest
+
+from myxo.prompt_cache import PromptCacheManager
+
+
+class TestPromptCacheManagerInit:
+    """Test PromptCacheManager initialization."""
+
+    def test_init_with_cacheable_prefixes(self):
+        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+        assert manager.cacheable_prefixes == ["Ship's Log", "Skills"]
+
+    def test_init_with_empty_prefixes(self):
+        manager = PromptCacheManager(cacheable_prefixes=[])
+        assert manager.cacheable_prefixes == []
+
+    def test_init_default_stats(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        stats = manager.get_cache_stats()
+        assert stats["cache_hits"] == 0
+        assert stats["cache_misses"] == 0
+        assert stats["total_requests"] == 0
+
+
+class TestIsCacheable:
+    """Test cache eligibility detection."""
+
+    def test_content_matching_prefix_is_cacheable(self):
+        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+        assert manager.is_cacheable("Ship's Log: Entry 42") is True
+
+    def test_content_matching_second_prefix_is_cacheable(self):
+        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+        assert manager.is_cacheable("Skills: Python, Rust") is True
+
+    def test_content_not_matching_any_prefix(self):
+        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+        assert manager.is_cacheable("User asked a question") is False
+
+    def test_empty_content_is_not_cacheable(self):
+        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log"])
+        assert manager.is_cacheable("") is False
+
+    def test_no_prefixes_means_nothing_cacheable(self):
+        manager = PromptCacheManager(cacheable_prefixes=[])
+        assert manager.is_cacheable("Ship's Log: Entry 1") is False
+
+
+class TestPrepareMessages:
+    """Test message preparation with cache_control injection."""
+
+    def test_adds_cache_control_to_cacheable_string_content(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [
+            {"role": "user", "content": "System prompt content"},
+        ]
+        result = manager.prepare_messages(messages)
+        assert result[0]["content"] == [
+            {
+                "type": "text",
+                "text": "System prompt content",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+    def test_adds_cache_control_to_cacheable_block_content(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "System instructions here"},
+                    {"type": "text", "text": "User question"},
+                ],
+            },
+        ]
+        result = manager.prepare_messages(messages)
+        assert result[0]["content"][1] == {"type": "text", "text": "User question"}
+
+    def test_does_not_modify_non_cacheable_content(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [
+            {"role": "user", "content": "Hello, how are you?"},
+        ]
+        result = manager.prepare_messages(messages)
+        assert result[0]["content"] == "Hello, how are you?"
+
+    def test_preserves_message_role(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [
+            {"role": "system", "content": "System: be helpful"},
+        ]
+        result = manager.prepare_messages(messages)
+        assert result[0]["role"] == "system"
+
+    def test_handles_multiple_messages(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System", "Skills"])
+        messages = [
+            {"role": "system", "content": "System: be helpful"},
+            {"role": "user", "content": "Skills: Python"},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        result = manager.prepare_messages(messages)
+        # First message should have cache_control
+        assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        # Second message should have cache_control
+        assert result[1]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        # Third message should NOT have cache_control
+        assert result[2]["content"] == "What is 2+2?"
+
+    def test_does_not_mutate_original_messages(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [
+            {"role": "user", "content": "System prompt content"},
+        ]
+        original_content = messages[0]["content"]
+        manager.prepare_messages(messages)
+        assert messages[0]["content"] == original_content
+
+    def test_empty_messages_returns_empty(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        result = manager.prepare_messages([])
+        assert result == []
+
+
+class TestCacheHashDetection:
+    """Test content hash-based cache hit/miss detection."""
+
+    def test_same_content_is_cache_hit(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [{"role": "system", "content": "System: be helpful"}]
+        manager.prepare_messages(messages)
+        manager.prepare_messages(messages)
+        stats = manager.get_cache_stats()
+        assert stats["cache_hits"] == 1
+
+    def test_different_content_is_cache_miss(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages1 = [{"role": "system", "content": "System: be helpful"}]
+        messages2 = [{"role": "system", "content": "System: be concise"}]
+        manager.prepare_messages(messages1)
+        manager.prepare_messages(messages2)
+        stats = manager.get_cache_stats()
+        assert stats["cache_hits"] == 0
+        assert stats["cache_misses"] == 2
+
+    def test_non_cacheable_content_not_tracked(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [{"role": "user", "content": "Hello"}]
+        manager.prepare_messages(messages)
+        manager.prepare_messages(messages)
+        stats = manager.get_cache_stats()
+        assert stats["total_requests"] == 0
+
+
+class TestGetCacheStats:
+    """Test cache statistics reporting."""
+
+    def test_hit_rate_calculation(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        messages = [{"role": "system", "content": "System: be helpful"}]
+        manager.prepare_messages(messages)
+        manager.prepare_messages(messages)
+        manager.prepare_messages(messages)
+        stats = manager.get_cache_stats()
+        assert stats["total_requests"] == 3
+        assert stats["cache_hits"] == 2
+        assert stats["cache_misses"] == 1
+        assert stats["hit_rate"] == pytest.approx(2 / 3)
+
+    def test_hit_rate_zero_when_no_requests(self):
+        manager = PromptCacheManager(cacheable_prefixes=["System"])
+        stats = manager.get_cache_stats()
+        assert stats["hit_rate"] == 0.0

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -4,7 +4,6 @@ import pytest
 
 from myxo.prompt_cache import PromptCacheManager
 
-
 # --- Initialization ---
 
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -5,172 +5,215 @@ import pytest
 from myxo.prompt_cache import PromptCacheManager
 
 
-class TestPromptCacheManagerInit:
-    """Test PromptCacheManager initialization."""
-
-    def test_init_with_cacheable_prefixes(self):
-        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
-        assert manager.cacheable_prefixes == ["Ship's Log", "Skills"]
-
-    def test_init_with_empty_prefixes(self):
-        manager = PromptCacheManager(cacheable_prefixes=[])
-        assert manager.cacheable_prefixes == []
-
-    def test_init_default_stats(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        stats = manager.get_cache_stats()
-        assert stats["cache_hits"] == 0
-        assert stats["cache_misses"] == 0
-        assert stats["total_requests"] == 0
+# --- Initialization ---
 
 
-class TestIsCacheable:
-    """Test cache eligibility detection."""
-
-    def test_content_matching_prefix_is_cacheable(self):
-        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
-        assert manager.is_cacheable("Ship's Log: Entry 42") is True
-
-    def test_content_matching_second_prefix_is_cacheable(self):
-        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
-        assert manager.is_cacheable("Skills: Python, Rust") is True
-
-    def test_content_not_matching_any_prefix(self):
-        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
-        assert manager.is_cacheable("User asked a question") is False
-
-    def test_empty_content_is_not_cacheable(self):
-        manager = PromptCacheManager(cacheable_prefixes=["Ship's Log"])
-        assert manager.is_cacheable("") is False
-
-    def test_no_prefixes_means_nothing_cacheable(self):
-        manager = PromptCacheManager(cacheable_prefixes=[])
-        assert manager.is_cacheable("Ship's Log: Entry 1") is False
+def test_init_with_cacheable_prefixes():
+    manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+    assert manager.cacheable_prefixes == ["Ship's Log", "Skills"]
 
 
-class TestPrepareMessages:
-    """Test message preparation with cache_control injection."""
-
-    def test_adds_cache_control_to_cacheable_string_content(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [
-            {"role": "user", "content": "System prompt content"},
-        ]
-        result = manager.prepare_messages(messages)
-        assert result[0]["content"] == [
-            {
-                "type": "text",
-                "text": "System prompt content",
-                "cache_control": {"type": "ephemeral"},
-            }
-        ]
-
-    def test_adds_cache_control_to_cacheable_block_content(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "System instructions here"},
-                    {"type": "text", "text": "User question"},
-                ],
-            },
-        ]
-        result = manager.prepare_messages(messages)
-        assert result[0]["content"][1] == {"type": "text", "text": "User question"}
-
-    def test_does_not_modify_non_cacheable_content(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [
-            {"role": "user", "content": "Hello, how are you?"},
-        ]
-        result = manager.prepare_messages(messages)
-        assert result[0]["content"] == "Hello, how are you?"
-
-    def test_preserves_message_role(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [
-            {"role": "system", "content": "System: be helpful"},
-        ]
-        result = manager.prepare_messages(messages)
-        assert result[0]["role"] == "system"
-
-    def test_handles_multiple_messages(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System", "Skills"])
-        messages = [
-            {"role": "system", "content": "System: be helpful"},
-            {"role": "user", "content": "Skills: Python"},
-            {"role": "user", "content": "What is 2+2?"},
-        ]
-        result = manager.prepare_messages(messages)
-        # First message should have cache_control
-        assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
-        # Second message should have cache_control
-        assert result[1]["content"][0]["cache_control"] == {"type": "ephemeral"}
-        # Third message should NOT have cache_control
-        assert result[2]["content"] == "What is 2+2?"
-
-    def test_does_not_mutate_original_messages(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [
-            {"role": "user", "content": "System prompt content"},
-        ]
-        original_content = messages[0]["content"]
-        manager.prepare_messages(messages)
-        assert messages[0]["content"] == original_content
-
-    def test_empty_messages_returns_empty(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        result = manager.prepare_messages([])
-        assert result == []
+def test_init_with_empty_prefixes():
+    manager = PromptCacheManager(cacheable_prefixes=[])
+    assert manager.cacheable_prefixes == []
 
 
-class TestCacheHashDetection:
-    """Test content hash-based cache hit/miss detection."""
-
-    def test_same_content_is_cache_hit(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [{"role": "system", "content": "System: be helpful"}]
-        manager.prepare_messages(messages)
-        manager.prepare_messages(messages)
-        stats = manager.get_cache_stats()
-        assert stats["cache_hits"] == 1
-
-    def test_different_content_is_cache_miss(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages1 = [{"role": "system", "content": "System: be helpful"}]
-        messages2 = [{"role": "system", "content": "System: be concise"}]
-        manager.prepare_messages(messages1)
-        manager.prepare_messages(messages2)
-        stats = manager.get_cache_stats()
-        assert stats["cache_hits"] == 0
-        assert stats["cache_misses"] == 2
-
-    def test_non_cacheable_content_not_tracked(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [{"role": "user", "content": "Hello"}]
-        manager.prepare_messages(messages)
-        manager.prepare_messages(messages)
-        stats = manager.get_cache_stats()
-        assert stats["total_requests"] == 0
+def test_init_default_stats():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    stats = manager.get_cache_stats()
+    assert stats["cache_hits"] == 0
+    assert stats["cache_misses"] == 0
+    assert stats["total_requests"] == 0
 
 
-class TestGetCacheStats:
-    """Test cache statistics reporting."""
+# --- is_cacheable ---
 
-    def test_hit_rate_calculation(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        messages = [{"role": "system", "content": "System: be helpful"}]
-        manager.prepare_messages(messages)
-        manager.prepare_messages(messages)
-        manager.prepare_messages(messages)
-        stats = manager.get_cache_stats()
-        assert stats["total_requests"] == 3
-        assert stats["cache_hits"] == 2
-        assert stats["cache_misses"] == 1
-        assert stats["hit_rate"] == pytest.approx(2 / 3)
 
-    def test_hit_rate_zero_when_no_requests(self):
-        manager = PromptCacheManager(cacheable_prefixes=["System"])
-        stats = manager.get_cache_stats()
-        assert stats["hit_rate"] == 0.0
+def test_content_matching_prefix_is_cacheable():
+    manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+    assert manager.is_cacheable("Ship's Log: Entry 42") is True
+
+
+def test_content_matching_second_prefix_is_cacheable():
+    manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+    assert manager.is_cacheable("Skills: Python, Rust") is True
+
+
+def test_content_not_matching_any_prefix():
+    manager = PromptCacheManager(cacheable_prefixes=["Ship's Log", "Skills"])
+    assert manager.is_cacheable("User asked a question") is False
+
+
+def test_empty_content_is_not_cacheable():
+    manager = PromptCacheManager(cacheable_prefixes=["Ship's Log"])
+    assert manager.is_cacheable("") is False
+
+
+def test_no_prefixes_means_nothing_cacheable():
+    manager = PromptCacheManager(cacheable_prefixes=[])
+    assert manager.is_cacheable("Ship's Log: Entry 1") is False
+
+
+# --- prepare_messages ---
+
+
+def test_adds_cache_control_to_cacheable_string_content():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [
+        {"role": "user", "content": "System prompt content"},
+    ]
+    result = manager.prepare_messages(messages)
+    assert result[0]["content"] == [
+        {
+            "type": "text",
+            "text": "System prompt content",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def test_adds_cache_control_to_cacheable_block_content():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "System instructions here"},
+                {"type": "text", "text": "User question"},
+            ],
+        },
+    ]
+    result = manager.prepare_messages(messages)
+    assert result[0]["content"][1] == {"type": "text", "text": "User question"}
+
+
+def test_does_not_modify_non_cacheable_content():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+    result = manager.prepare_messages(messages)
+    assert result[0]["content"] == "Hello, how are you?"
+
+
+def test_preserves_message_role():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [
+        {"role": "system", "content": "System: be helpful"},
+    ]
+    result = manager.prepare_messages(messages)
+    assert result[0]["role"] == "system"
+
+
+def test_handles_multiple_messages():
+    manager = PromptCacheManager(cacheable_prefixes=["System", "Skills"])
+    messages = [
+        {"role": "system", "content": "System: be helpful"},
+        {"role": "user", "content": "Skills: Python"},
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+    result = manager.prepare_messages(messages)
+    assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert result[1]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert result[2]["content"] == "What is 2+2?"
+
+
+def test_does_not_mutate_original_messages():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [
+        {"role": "user", "content": "System prompt content"},
+    ]
+    original_content = messages[0]["content"]
+    manager.prepare_messages(messages)
+    assert messages[0]["content"] == original_content
+
+
+def test_empty_messages_returns_empty():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    result = manager.prepare_messages([])
+    assert result == []
+
+
+def test_skips_message_without_content_key():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [
+        {"role": "user"},
+        {"role": "user", "content": "System prompt"},
+    ]
+    result = manager.prepare_messages(messages)
+    assert "content" not in result[0]
+    assert result[1]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_skips_non_dict_blocks_in_list_content():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                "plain string block",
+                {"type": "text", "text": "System instructions"},
+                42,
+            ],
+        },
+    ]
+    result = manager.prepare_messages(messages)
+    # Non-dict blocks are left as-is
+    assert result[0]["content"][0] == "plain string block"
+    assert result[0]["content"][2] == 42
+    # Dict block with cacheable content gets cache_control
+    assert result[0]["content"][1]["cache_control"] == {"type": "ephemeral"}
+
+
+# --- Cache hash detection ---
+
+
+def test_same_content_is_cache_hit():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [{"role": "system", "content": "System: be helpful"}]
+    manager.prepare_messages(messages)
+    manager.prepare_messages(messages)
+    stats = manager.get_cache_stats()
+    assert stats["cache_hits"] == 1
+
+
+def test_different_content_is_cache_miss():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages1 = [{"role": "system", "content": "System: be helpful"}]
+    messages2 = [{"role": "system", "content": "System: be concise"}]
+    manager.prepare_messages(messages1)
+    manager.prepare_messages(messages2)
+    stats = manager.get_cache_stats()
+    assert stats["cache_hits"] == 0
+    assert stats["cache_misses"] == 2
+
+
+def test_non_cacheable_content_not_tracked():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [{"role": "user", "content": "Hello"}]
+    manager.prepare_messages(messages)
+    manager.prepare_messages(messages)
+    stats = manager.get_cache_stats()
+    assert stats["total_requests"] == 0
+
+
+# --- Cache statistics ---
+
+
+def test_hit_rate_calculation():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    messages = [{"role": "system", "content": "System: be helpful"}]
+    manager.prepare_messages(messages)
+    manager.prepare_messages(messages)
+    manager.prepare_messages(messages)
+    stats = manager.get_cache_stats()
+    assert stats["total_requests"] == 3
+    assert stats["cache_hits"] == 2
+    assert stats["cache_misses"] == 1
+    assert stats["hit_rate"] == pytest.approx(2 / 3)
+
+
+def test_hit_rate_zero_when_no_requests():
+    manager = PromptCacheManager(cacheable_prefixes=["System"])
+    stats = manager.get_cache_stats()
+    assert stats["hit_rate"] == 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -261,7 +263,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.15" },
+    { name = "ty", specifier = ">=0.0.1a7" },
+]
 
 [[package]]
 name = "opentelemetry-api"
@@ -531,6 +537,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+]
+
+[[package]]
 name = "semver"
 version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -546,6 +577,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/96/652a425030f95dc2c9548d9019e52502e17079e1daeefbc4036f1c0905b4/ty-0.0.24.tar.gz", hash = "sha256:9fe42f6b98207bdaef51f71487d6d087f2cb02555ee3939884d779b2b3cc8bfc", size = 5354286, upload-time = "2026-03-19T16:55:57.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/e5/34457ee11708e734ba81ad65723af83030e484f961e281d57d1eecf08951/ty-0.0.24-py3-none-linux_armv6l.whl", hash = "sha256:1ab4f1f61334d533a3fdf5d9772b51b1300ac5da4f3cdb0be9657a3ccb2ce3e7", size = 10394877, upload-time = "2026-03-19T16:55:54.246Z" },
+    { url = "https://files.pythonhosted.org/packages/44/81/bc9a1b1a87f43db15ab64ad781a4f999734ec3b470ad042624fa875b20e6/ty-0.0.24-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:facbf2c4aaa6985229e08f8f9bf152215eb078212f22b5c2411f35386688ab42", size = 10211109, upload-time = "2026-03-19T16:55:28.554Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/cfc805adeaa61d63ba3ea71127efa7d97c40ba36d97ee7bd957341d05107/ty-0.0.24-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b6d2a3b6d4470c483552a31e9b368c86f154dcc964bccb5406159dc9cd362246", size = 9694769, upload-time = "2026-03-19T16:55:34.309Z" },
+    { url = "https://files.pythonhosted.org/packages/33/09/edc220726b6ec44a58900401f6b27140997ef15026b791e26b69a6e69eb5/ty-0.0.24-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c94c25d0500939fd5f8f16ce41cbed5b20528702c1d649bf80300253813f0a2", size = 10176287, upload-time = "2026-03-19T16:55:37.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/bf/cbe2227be711e65017655d8ee4d050f4c92b113fb4dc4c3bd6a19d3a86d8/ty-0.0.24-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:89cbe7bc7df0fab02dbd8cda79b737df83f1ef7fb573b08c0ee043dc68cffb08", size = 10214832, upload-time = "2026-03-19T16:56:08.518Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1d/d15803ee47e9143d10e10bd81ccc14761d08758082bda402950685f0ddfe/ty-0.0.24-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db2c5d269bcc9b764850c99f457b5018a79b3ef40ecfbc03344e65effd6cf743", size = 10709892, upload-time = "2026-03-19T16:56:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/36/12/6db0d86c477147f67b9052de209421d76c3e855197b000c25fcbbe86b3a2/ty-0.0.24-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba44512db5b97c3bbd59d93e11296e8548d0c9a3bdd1280de36d7ff22d351896", size = 11280872, upload-time = "2026-03-19T16:56:02.899Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fc/155fe83a97c06d33ccc9e0f428258b32df2e08a428300c715d34757f0111/ty-0.0.24-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a52b7f589c3205512a9c50ba5b2b1e8c0698b72e51b8b9285c90420c06f1cae8", size = 11060520, upload-time = "2026-03-19T16:55:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f1/32c05a1c4c3c2a95c5b7361dee03a9bf1231d4ad096b161c838b45bce5a0/ty-0.0.24-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7981df5c709c054da4ac5d7c93f8feb8f45e69e829e4461df4d5f0988fe67d04", size = 10791455, upload-time = "2026-03-19T16:55:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2c/53c1ea6bedfa4d4ab64d4de262d8f5e405ecbffefd364459c628c0310d33/ty-0.0.24-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b2860151ad95a00d0f0280b8fef79900d08dcd63276b57e6e5774f2c055979c5", size = 10156708, upload-time = "2026-03-19T16:55:45.563Z" },
+    { url = "https://files.pythonhosted.org/packages/45/39/7d2919cf194707169474d80720a5f3d793e983416f25e7ffcf80504c9df2/ty-0.0.24-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5674a1146d927ab77ff198a88e0c4505134ced342a0e7d1beb4a076a728b7496", size = 10236263, upload-time = "2026-03-19T16:55:31.474Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7f/48eac722f2fd12a5b7aae0effdcb75c46053f94b783d989e3ef0d7380082/ty-0.0.24-py3-none-musllinux_1_2_i686.whl", hash = "sha256:438ecbf1608a9b16dd84502f3f1b23ef2ef32bbd0ab3e0ca5a82f0e0d1cd41ea", size = 10402559, upload-time = "2026-03-19T16:55:39.602Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e0/8cf868b9749ce1e5166462759545964e95b02353243594062b927d8bff2a/ty-0.0.24-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ddeed3098dd92a83964e7aa7b41e509ba3530eb539fc4cd8322ff64a09daf1f5", size = 10893684, upload-time = "2026-03-19T16:55:51.439Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9f/f54bf3be01d2c2ed731d10a5afa3324dc66f987a6ae0a4a6cbfa2323d080/ty-0.0.24-py3-none-win32.whl", hash = "sha256:83013fb3a4764a8f8bcc6ca11ff8bdfd8c5f719fc249241cb2b8916e80778eb1", size = 9781542, upload-time = "2026-03-19T16:56:11.588Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/49/c004c5cc258b10b3a145666e9a9c28ae7678bc958c8926e8078d5d769081/ty-0.0.24-py3-none-win_amd64.whl", hash = "sha256:748a60eb6912d1cf27aaab105ffadb6f4d2e458a3fcadfbd3cf26db0d8062eeb", size = 10764801, upload-time = "2026-03-19T16:55:42.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/006a074e185bfccf5e4c026015245ab4fcd2362b13a8d24cf37a277909a9/ty-0.0.24-py3-none-win_arm64.whl", hash = "sha256:280a3d31e86d0721947238f17030c33f0911cae851d108ea9f4e3ab12a5ed01f", size = 10194093, upload-time = "2026-03-19T16:55:48.303Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add PromptCacheManager class that injects cache_control: {type: ephemeral} into messages with immutable content (Ship's Log, Skills, etc.)
- Prefix-based cache eligibility detection and content-hash-based hit/miss tracking with statistics
- 20 tests covering initialization, cacheability checks, message preparation, hash detection, and stats

## Test plan
- [x] All 20 new tests pass (uv run pytest tests/test_prompt_cache.py)
- [x] Full test suite (226 tests) passes

Closes #38