### PR TITLE
feat: ✨ implement ETag conditional request caching

### DIFF
--- a/src/myxo/etag_cache.py
+++ b/src/myxo/etag_cache.py
@@ -21,9 +21,7 @@ class ETagCache:
         """Return the stored ETag for *url*, or ``None`` if not cached."""
         return self._etags.get(url)
 
-    def build_headers(
-        self, url: str, extra_headers: dict[str, str] | None = None
-    ) -> dict[str, str]:
+    def build_headers(self, url: str, extra_headers: dict[str, str] | None = None) -> dict[str, str]:
         """Build request headers, adding ``If-None-Match`` when an ETag is cached.
 
         Parameters

--- a/src/myxo/etag_cache.py
+++ b/src/myxo/etag_cache.py
@@ -1,0 +1,76 @@
+"""ETagCache - conditional request support with ETag/If-None-Match."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ETagCache:
+    """Cache that stores ETags and response bodies for conditional requests.
+
+    Supports building ``If-None-Match`` headers and handling 304 responses
+    to avoid counting against GitHub API rate limits.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty ETag cache."""
+        self._etags: dict[str, str] = {}
+        self._bodies: dict[str, Any] = {}
+
+    def get_etag(self, url: str) -> str | None:
+        """Return the stored ETag for *url*, or ``None`` if not cached."""
+        return self._etags.get(url)
+
+    def build_headers(
+        self, url: str, extra_headers: dict[str, str] | None = None
+    ) -> dict[str, str]:
+        """Build request headers, adding ``If-None-Match`` when an ETag is cached.
+
+        Parameters
+        ----------
+        url:
+            The request URL to look up a cached ETag for.
+        extra_headers:
+            Optional additional headers to merge into the result.
+        """
+        headers: dict[str, str] = {}
+        if extra_headers:
+            headers.update(extra_headers)
+        etag = self.get_etag(url)
+        if etag is not None:
+            headers["If-None-Match"] = etag
+        return headers
+
+    def handle_response(
+        self,
+        url: str,
+        status_code: int,
+        etag: str | None,
+        body: Any,
+    ) -> Any:
+        """Process an HTTP response, updating the cache as needed.
+
+        * **200** -- stores the *etag* (if present) and *body*, returns *body*.
+        * **304** -- returns the previously cached body (or ``None``).
+        * Other status codes -- returns *body* as-is without caching.
+        """
+        if status_code == 304:
+            return self._bodies.get(url)
+
+        if status_code == 200:
+            if etag is not None:
+                self._etags[url] = etag
+            else:
+                self._etags.pop(url, None)
+            self._bodies[url] = body
+
+        return body
+
+    def get_cached_body(self, url: str) -> Any | None:
+        """Return the cached response body for *url*, or ``None``."""
+        return self._bodies.get(url)
+
+    def clear(self) -> None:
+        """Remove all cached ETags and bodies."""
+        self._etags.clear()
+        self._bodies.clear()

--- a/src/myxo/etag_cache.py
+++ b/src/myxo/etag_cache.py
@@ -9,7 +9,8 @@ class ETagCache:
     """Cache that stores ETags and response bodies for conditional requests.
 
     Supports building ``If-None-Match`` headers and handling 304 responses
-    to avoid counting against GitHub API rate limits.
+    to enable GitHub's conditional request handling (304 Not Modified) which
+    does not count against rate limits.
     """
 
     def __init__(self) -> None:
@@ -24,12 +25,9 @@ class ETagCache:
     def build_headers(self, url: str, extra_headers: dict[str, str] | None = None) -> dict[str, str]:
         """Build request headers, adding ``If-None-Match`` when an ETag is cached.
 
-        Parameters
-        ----------
-        url:
-            The request URL to look up a cached ETag for.
-        extra_headers:
-            Optional additional headers to merge into the result.
+        Args:
+            url: The request URL to look up a cached ETag for.
+            extra_headers: Optional additional headers to merge into the result.
         """
         headers: dict[str, str] = {}
         if extra_headers:

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from myxo.etag_cache import ETagCache
 
 

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from myxo.etag_cache import ETagCache
 
-
 # --- init ---
 
 

--- a/tests/test_etag_cache.py
+++ b/tests/test_etag_cache.py
@@ -1,0 +1,169 @@
+"""Tests for ETagCache - conditional request support with ETag/If-None-Match."""
+
+from __future__ import annotations
+
+import pytest
+
+from myxo.etag_cache import ETagCache
+
+
+# --- init ---
+
+
+def test_etag_cache_initializes_empty():
+    cache = ETagCache()
+    assert cache.get_etag("https://api.github.com/repos/foo/bar") is None
+    assert cache.get_cached_body("https://api.github.com/repos/foo/bar") is None
+
+
+# --- get_etag / store via handle_response ---
+
+
+def test_get_etag_returns_none_for_unknown_url():
+    cache = ETagCache()
+    assert cache.get_etag("https://api.github.com/unknown") is None
+
+
+def test_get_etag_returns_stored_etag_after_200():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    cache.handle_response(url, status_code=200, etag='"abc123"', body={"id": 1})
+    assert cache.get_etag(url) == '"abc123"'
+
+
+def test_get_etag_updates_on_new_200():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    cache.handle_response(url, status_code=200, etag='"v1"', body={"v": 1})
+    cache.handle_response(url, status_code=200, etag='"v2"', body={"v": 2})
+    assert cache.get_etag(url) == '"v2"'
+
+
+# --- build_headers ---
+
+
+def test_build_headers_without_cached_etag():
+    cache = ETagCache()
+    headers = cache.build_headers("https://api.github.com/repos/foo/bar")
+    assert "If-None-Match" not in headers
+
+
+def test_build_headers_with_cached_etag():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    cache.handle_response(url, status_code=200, etag='"abc123"', body={"id": 1})
+    headers = cache.build_headers(url)
+    assert headers["If-None-Match"] == '"abc123"'
+
+
+def test_build_headers_merges_extra_headers():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    cache.handle_response(url, status_code=200, etag='"abc123"', body={"id": 1})
+    headers = cache.build_headers(url, extra_headers={"Authorization": "token xyz"})
+    assert headers["If-None-Match"] == '"abc123"'
+    assert headers["Authorization"] == "token xyz"
+
+
+def test_build_headers_extra_headers_without_etag():
+    cache = ETagCache()
+    url = "https://api.github.com/unknown"
+    headers = cache.build_headers(url, extra_headers={"Accept": "application/json"})
+    assert "If-None-Match" not in headers
+    assert headers["Accept"] == "application/json"
+
+
+# --- handle_response ---
+
+
+def test_handle_response_200_stores_body_and_etag():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    body = {"name": "bar", "full_name": "foo/bar"}
+    result = cache.handle_response(url, status_code=200, etag='"etag1"', body=body)
+    assert result == body
+    assert cache.get_etag(url) == '"etag1"'
+    assert cache.get_cached_body(url) == body
+
+
+def test_handle_response_304_returns_cached_body():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    original_body = {"name": "bar"}
+    cache.handle_response(url, status_code=200, etag='"etag1"', body=original_body)
+
+    result = cache.handle_response(url, status_code=304, etag=None, body=None)
+    assert result == original_body
+
+
+def test_handle_response_304_without_prior_cache_returns_none():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    result = cache.handle_response(url, status_code=304, etag=None, body=None)
+    assert result is None
+
+
+def test_handle_response_200_without_etag_stores_body_only():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    body = {"name": "bar"}
+    result = cache.handle_response(url, status_code=200, etag=None, body=body)
+    assert result == body
+    assert cache.get_etag(url) is None
+    assert cache.get_cached_body(url) == body
+
+
+def test_handle_response_200_replaces_previous_cache():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    cache.handle_response(url, status_code=200, etag='"v1"', body={"v": 1})
+    cache.handle_response(url, status_code=200, etag='"v2"', body={"v": 2})
+    assert cache.get_cached_body(url) == {"v": 2}
+    assert cache.get_etag(url) == '"v2"'
+
+
+# --- get_cached_body ---
+
+
+def test_get_cached_body_returns_none_for_unknown_url():
+    cache = ETagCache()
+    assert cache.get_cached_body("https://api.github.com/unknown") is None
+
+
+def test_get_cached_body_returns_stored_body():
+    cache = ETagCache()
+    url = "https://api.github.com/repos/foo/bar"
+    body = [{"id": 1}, {"id": 2}]
+    cache.handle_response(url, status_code=200, etag='"etag1"', body=body)
+    assert cache.get_cached_body(url) == body
+
+
+# --- clear ---
+
+
+def test_clear_removes_all_entries():
+    cache = ETagCache()
+    url1 = "https://api.github.com/repos/foo/bar"
+    url2 = "https://api.github.com/repos/baz/qux"
+    cache.handle_response(url1, status_code=200, etag='"e1"', body={"a": 1})
+    cache.handle_response(url2, status_code=200, etag='"e2"', body={"b": 2})
+    cache.clear()
+    assert cache.get_etag(url1) is None
+    assert cache.get_etag(url2) is None
+    assert cache.get_cached_body(url1) is None
+    assert cache.get_cached_body(url2) is None
+
+
+# --- multiple URLs ---
+
+
+def test_independent_urls_do_not_interfere():
+    cache = ETagCache()
+    url1 = "https://api.github.com/repos/foo/bar"
+    url2 = "https://api.github.com/repos/baz/qux"
+    cache.handle_response(url1, status_code=200, etag='"e1"', body={"a": 1})
+    cache.handle_response(url2, status_code=200, etag='"e2"', body={"b": 2})
+    assert cache.get_etag(url1) == '"e1"'
+    assert cache.get_etag(url2) == '"e2"'
+    assert cache.get_cached_body(url1) == {"a": 1}
+    assert cache.get_cached_body(url2) == {"b": 2}

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -261,7 +263,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.15" },
+    { name = "ty", specifier = ">=0.0.1a7" },
+]
 
 [[package]]
 name = "opentelemetry-api"
@@ -531,6 +537,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+]
+
+[[package]]
 name = "semver"
 version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -546,6 +577,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/96/652a425030f95dc2c9548d9019e52502e17079e1daeefbc4036f1c0905b4/ty-0.0.24.tar.gz", hash = "sha256:9fe42f6b98207bdaef51f71487d6d087f2cb02555ee3939884d779b2b3cc8bfc", size = 5354286, upload-time = "2026-03-19T16:55:57.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/e5/34457ee11708e734ba81ad65723af83030e484f961e281d57d1eecf08951/ty-0.0.24-py3-none-linux_armv6l.whl", hash = "sha256:1ab4f1f61334d533a3fdf5d9772b51b1300ac5da4f3cdb0be9657a3ccb2ce3e7", size = 10394877, upload-time = "2026-03-19T16:55:54.246Z" },
+    { url = "https://files.pythonhosted.org/packages/44/81/bc9a1b1a87f43db15ab64ad781a4f999734ec3b470ad042624fa875b20e6/ty-0.0.24-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:facbf2c4aaa6985229e08f8f9bf152215eb078212f22b5c2411f35386688ab42", size = 10211109, upload-time = "2026-03-19T16:55:28.554Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/cfc805adeaa61d63ba3ea71127efa7d97c40ba36d97ee7bd957341d05107/ty-0.0.24-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b6d2a3b6d4470c483552a31e9b368c86f154dcc964bccb5406159dc9cd362246", size = 9694769, upload-time = "2026-03-19T16:55:34.309Z" },
+    { url = "https://files.pythonhosted.org/packages/33/09/edc220726b6ec44a58900401f6b27140997ef15026b791e26b69a6e69eb5/ty-0.0.24-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c94c25d0500939fd5f8f16ce41cbed5b20528702c1d649bf80300253813f0a2", size = 10176287, upload-time = "2026-03-19T16:55:37.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/bf/cbe2227be711e65017655d8ee4d050f4c92b113fb4dc4c3bd6a19d3a86d8/ty-0.0.24-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:89cbe7bc7df0fab02dbd8cda79b737df83f1ef7fb573b08c0ee043dc68cffb08", size = 10214832, upload-time = "2026-03-19T16:56:08.518Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1d/d15803ee47e9143d10e10bd81ccc14761d08758082bda402950685f0ddfe/ty-0.0.24-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db2c5d269bcc9b764850c99f457b5018a79b3ef40ecfbc03344e65effd6cf743", size = 10709892, upload-time = "2026-03-19T16:56:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/36/12/6db0d86c477147f67b9052de209421d76c3e855197b000c25fcbbe86b3a2/ty-0.0.24-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba44512db5b97c3bbd59d93e11296e8548d0c9a3bdd1280de36d7ff22d351896", size = 11280872, upload-time = "2026-03-19T16:56:02.899Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fc/155fe83a97c06d33ccc9e0f428258b32df2e08a428300c715d34757f0111/ty-0.0.24-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a52b7f589c3205512a9c50ba5b2b1e8c0698b72e51b8b9285c90420c06f1cae8", size = 11060520, upload-time = "2026-03-19T16:55:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f1/32c05a1c4c3c2a95c5b7361dee03a9bf1231d4ad096b161c838b45bce5a0/ty-0.0.24-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7981df5c709c054da4ac5d7c93f8feb8f45e69e829e4461df4d5f0988fe67d04", size = 10791455, upload-time = "2026-03-19T16:55:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2c/53c1ea6bedfa4d4ab64d4de262d8f5e405ecbffefd364459c628c0310d33/ty-0.0.24-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b2860151ad95a00d0f0280b8fef79900d08dcd63276b57e6e5774f2c055979c5", size = 10156708, upload-time = "2026-03-19T16:55:45.563Z" },
+    { url = "https://files.pythonhosted.org/packages/45/39/7d2919cf194707169474d80720a5f3d793e983416f25e7ffcf80504c9df2/ty-0.0.24-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5674a1146d927ab77ff198a88e0c4505134ced342a0e7d1beb4a076a728b7496", size = 10236263, upload-time = "2026-03-19T16:55:31.474Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7f/48eac722f2fd12a5b7aae0effdcb75c46053f94b783d989e3ef0d7380082/ty-0.0.24-py3-none-musllinux_1_2_i686.whl", hash = "sha256:438ecbf1608a9b16dd84502f3f1b23ef2ef32bbd0ab3e0ca5a82f0e0d1cd41ea", size = 10402559, upload-time = "2026-03-19T16:55:39.602Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e0/8cf868b9749ce1e5166462759545964e95b02353243594062b927d8bff2a/ty-0.0.24-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ddeed3098dd92a83964e7aa7b41e509ba3530eb539fc4cd8322ff64a09daf1f5", size = 10893684, upload-time = "2026-03-19T16:55:51.439Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9f/f54bf3be01d2c2ed731d10a5afa3324dc66f987a6ae0a4a6cbfa2323d080/ty-0.0.24-py3-none-win32.whl", hash = "sha256:83013fb3a4764a8f8bcc6ca11ff8bdfd8c5f719fc249241cb2b8916e80778eb1", size = 9781542, upload-time = "2026-03-19T16:56:11.588Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/49/c004c5cc258b10b3a145666e9a9c28ae7678bc958c8926e8078d5d769081/ty-0.0.24-py3-none-win_amd64.whl", hash = "sha256:748a60eb6912d1cf27aaab105ffadb6f4d2e458a3fcadfbd3cf26db0d8062eeb", size = 10764801, upload-time = "2026-03-19T16:55:42.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/006a074e185bfccf5e4c026015245ab4fcd2362b13a8d24cf37a277909a9/ty-0.0.24-py3-none-win_arm64.whl", hash = "sha256:280a3d31e86d0721947238f17030c33f0911cae851d108ea9f4e3ab12a5ed01f", size = 10194093, upload-time = "2026-03-19T16:55:48.303Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `ETagCache` class for conditional HTTP requests with If-None-Match headers
- 304 responses return cached body without counting against rate limits
- 17 test cases covering all cache operations

Closes #46