### PR TITLE
refactor: ♻️ rename pseudopod→myxo terminology

### DIFF
--- a/.claude/skills/commit-rules/SKILL.md
+++ b/.claude/skills/commit-rules/SKILL.md
@@ -79,7 +79,7 @@ This will be used by the Protocol agent for task decomposition.
 ```
 
 ```
-test: ✅ add pseudopod execution tests
+test: ✅ add myxo execution tests
 
 Write failing tests first per TDD workflow.
 Tests cover spawn, execute, and report operations.
@@ -109,8 +109,8 @@ Refs #12
 Always separate test commits from implementation commits:
 
 ```
-test: ✅ add pseudopod execution tests          ← tests only (expected to fail)
-feat: ✨ implement pseudopod execution           ← implementation (tests pass)
+test: ✅ add myxo execution tests                ← tests only (expected to fail)
+feat: ✨ implement myxo execution                ← implementation (tests pass)
 refactor: ♻️ extract experiment validation logic ← refactor (tests still pass)
 ```
 

--- a/.github/workflows/myxo-procedure.yml
+++ b/.github/workflows/myxo-procedure.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   execute-procedure:
-    if: "github.event.label.name == 'state: pseudopod-ready'"
+    if: "github.event.label.name == 'state: myxo-ready'"
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,8 @@ jobs:
         run: |
           gh issue edit "$ISSUE_NUMBER" \
             --repo "$REPO" \
-            --remove-label "state: pseudopod-ready" \
-            --add-label "state: pseudopod-active"
+            --remove-label "state: myxo-ready" \
+            --add-label "state: myxo-active"
 
       - uses: actions/checkout@v4
 
@@ -47,8 +47,8 @@ jobs:
         run: |
           gh issue edit "$ISSUE_NUMBER" \
             --repo "$REPO" \
-            --remove-label "state: pseudopod-active" \
-            --add-label "state: pseudopod-complete"
+            --remove-label "state: myxo-active" \
+            --add-label "state: myxo-complete"
 
       - name: Mark abort on failure
         if: failure()
@@ -59,5 +59,5 @@ jobs:
         run: |
           gh issue edit "$ISSUE_NUMBER" \
             --repo "$REPO" \
-            --remove-label "state: pseudopod-active" \
-            --add-label "state: pseudopod-abort"
+            --remove-label "state: myxo-active" \
+            --add-label "state: myxo-abort"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ---
 
-Myxo `/ˈmɪk.soʊ/` orchestrates AI coding agents through a laboratory-experiment metaphor: a **Researcher** designs hypotheses, **Protocols** decompose them into steps, and **Pseudopods** extend outward to explore and implement solutions — all verified by rigorous **Assays** before **Publication**.
+Myxo `/ˈmɪk.soʊ/` orchestrates AI coding agents through a laboratory-experiment metaphor: a **Researcher** designs hypotheses, **Protocols** decompose them into steps, and **Myxos** (worker agents) explore and implement solutions — all verified by rigorous **Assays** before **Publication**.
 
 ---
 
@@ -31,10 +31,10 @@ Myxo uses a naming convention drawn from slime mold biology and experimental sci
 | Role | Pronunciation | Description |
 |------|---------------|-------------|
 | **Researcher** | — | The human operator. Designs experiments and makes final decisions. |
-| **Protocol** | — | The director agent. Decomposes a Hypothesis into parallel tasks and assigns them to Pseudopods. |
-| **Pseudopod** | `/ˈsjuː.doʊ.pɒd/` | Worker agents — the extending "false feet" of a slime mold that explore the environment and bring results back. |
-| **Assay** | `/ˈæs.eɪ/` | The reviewer agent. Performs quality analysis on Pseudopod output, including code review and risk evaluation. |
-| **Scribe** | — | The explainer agent. Generates documentation and summaries of changes. |
+| **Protocol** | — | The director agent. Decomposes a Hypothesis into parallel tasks and assigns them to Myxos. |
+| **Myxo** | `/ˈmɪk.soʊ/` | Worker agents — the cultured slime molds that explore the environment and bring results back. |
+| **Assay** | `/ˈæs.eɪ/` | The reviewer agent. Performs quality analysis on Myxo output, including code review and risk evaluation. |
+| **Report** | — | The explainer agent. Generates documentation and summaries of changes (experiment reports). |
 
 ### Concepts
 
@@ -52,7 +52,7 @@ Myxo uses a naming convention drawn from slime mold biology and experimental sci
 | **Petri** | `/ˈpiː.tri/` | Preview / staging environment — an isolated dish for running experiments safely. |
 | **Publication** | — | Production environment — verified results released to the world. |
 | **LabNote** | — | Global shared memory (S3 JSON). Knowledge accumulated across all experiments. |
-| **FieldNote** | — | Per-repository memory. Observations specific to one codebase. |
+| **BenchNote** | — | Per-repository memory. Observations specific to one codebase (bench notes from the lab). |
 | **.myxo/** | — | Configuration directory at the repository root. Contains rules, protocols, and agent definitions. |
 
 ---
@@ -69,8 +69,8 @@ flowchart TD
     H["📋 Hypothesis (GitHub Issue)"]
     P["🧪 Protocol"]
     LN[("📓 LabNote\n(shared memory)")]
-    P1["🦠 Pseudopod"]
-    P2["🦠 Pseudopod"]
+    P1["🦠 Myxo"]
+    P2["🦠 Myxo"]
     P3["🦠 ···"]
     A["🔬 Assay"]
     PR["📊 PeerReview"]
@@ -141,7 +141,7 @@ flowchart TD
 - **Remember without a brain** — leaving chemical traces as external memory
 - **Split and merge** — dividing to explore in parallel, fusing to share findings
 
-This is exactly how Myxo's agents work: they extend pseudopods into a codebase, explore multiple approaches in parallel, leave traces (LabNotes) for future reference, and converge on the optimal solution — all without central command.
+This is exactly how Myxo's agents work: they extend into a codebase like cultured slime molds, explore multiple approaches in parallel, leave traces (LabNotes) for future reference, and converge on the optimal solution — all without central command.
 
 ---
 

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -14,10 +14,10 @@ repo_name = config.require("repo")
 # ---------------------------------------------------------------------------
 LABELS: dict[str, str] = {
     # state
-    "state: pseudopod-ready": "0e8a16",
-    "state: pseudopod-active": "1d76db",
-    "state: pseudopod-abort": "b60205",
-    "state: pseudopod-complete": "0e8a16",
+    "state: myxo-ready": "0e8a16",
+    "state: myxo-active": "1d76db",
+    "state: myxo-abort": "b60205",
+    "state: myxo-complete": "0e8a16",
     "state: researcher-review": "fbca04",
     "state: scheduled-experiment": "c5def5",
     "state: hypothesis-hold": "d4c5f9",

--- a/src/myxo/cli.py
+++ b/src/myxo/cli.py
@@ -20,7 +20,7 @@ app = typer.Typer(
 
 _DEFAULT_CONFIG = '# Myxo repository configuration\nversion: "0.1"\n'
 _DEFAULT_RULES = "# Myxo Rules\n"
-_SUBDIRS = ("protocols", "procedures", "pseudopods")
+_SUBDIRS = ("protocols", "procedures", "myxos")
 
 
 @app.command()

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -37,14 +37,14 @@ def test_init_creates_rules_md(tmp_path: Path, monkeypatch):
 
 
 def test_init_creates_subdirectories(tmp_path: Path, monkeypatch):
-    """myxo init should create protocols/, procedures/, pseudopods/ subdirectories."""
+    """myxo init should create protocols/, procedures/, myxos/ subdirectories."""
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0
     myxo = tmp_path / ".myxo"
     assert (myxo / "protocols").is_dir()
     assert (myxo / "procedures").is_dir()
-    assert (myxo / "pseudopods").is_dir()
+    assert (myxo / "myxos").is_dir()
 
 
 def test_init_creates_gitkeep_in_subdirectories(tmp_path: Path, monkeypatch):
@@ -55,7 +55,7 @@ def test_init_creates_gitkeep_in_subdirectories(tmp_path: Path, monkeypatch):
     myxo = tmp_path / ".myxo"
     assert (myxo / "protocols" / ".gitkeep").is_file()
     assert (myxo / "procedures" / ".gitkeep").is_file()
-    assert (myxo / "pseudopods" / ".gitkeep").is_file()
+    assert (myxo / "myxos" / ".gitkeep").is_file()
 
 
 def test_init_fails_when_myxo_is_file(tmp_path: Path, monkeypatch):

--- a/tests/test_myxo_dir.py
+++ b/tests/test_myxo_dir.py
@@ -25,5 +25,5 @@ def test_procedures_dir_exists():
     assert (MYXO_DIR / "procedures").is_dir()
 
 
-def test_pseudopods_dir_exists():
-    assert (MYXO_DIR / "pseudopods").is_dir()
+def test_myxos_dir_exists():
+    assert (MYXO_DIR / "myxos").is_dir()

--- a/tests/test_pr_title_lint.py
+++ b/tests/test_pr_title_lint.py
@@ -31,7 +31,7 @@ def test_valid_chore_title():
 
 
 def test_valid_test_title():
-    result = _run("test: ✅ add pseudopod execution tests")
+    result = _run("test: ✅ add myxo execution tests")
     assert result.returncode == 0
 
 

--- a/tests/test_pulumi_labels.py
+++ b/tests/test_pulumi_labels.py
@@ -5,10 +5,10 @@ from pathlib import Path
 INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
 
 EXPECTED_LABELS = [
-    "state: pseudopod-ready",
-    "state: pseudopod-active",
-    "state: pseudopod-abort",
-    "state: pseudopod-complete",
+    "state: myxo-ready",
+    "state: myxo-active",
+    "state: myxo-abort",
+    "state: myxo-complete",
     "state: researcher-review",
     "state: scheduled-experiment",
     "state: hypothesis-hold",

--- a/tests/test_workflow_procedure.py
+++ b/tests/test_workflow_procedure.py
@@ -24,24 +24,24 @@ def test_triggers_on_issues_labeled():
     assert "labeled" in issues_config.get("types", []), "Workflow should trigger on labeled type"
 
 
-def test_references_pseudopod_ready_label():
+def test_references_myxo_ready_label():
     content = WORKFLOW.read_text()
-    assert "state: pseudopod-ready" in content, "Workflow should reference the pseudopod-ready label"
+    assert "state: myxo-ready" in content, "Workflow should reference the myxo-ready label"
 
 
-def test_references_pseudopod_active_label():
+def test_references_myxo_active_label():
     content = WORKFLOW.read_text()
-    assert "state: pseudopod-active" in content, "Workflow should reference the pseudopod-active label"
+    assert "state: myxo-active" in content, "Workflow should reference the myxo-active label"
 
 
-def test_references_pseudopod_complete_label():
+def test_references_myxo_complete_label():
     content = WORKFLOW.read_text()
-    assert "state: pseudopod-complete" in content, "Workflow should reference the pseudopod-complete label"
+    assert "state: myxo-complete" in content, "Workflow should reference the myxo-complete label"
 
 
-def test_references_pseudopod_abort_label():
+def test_references_myxo_abort_label():
     content = WORKFLOW.read_text()
-    assert "state: pseudopod-abort" in content, "Workflow should reference the pseudopod-abort label"
+    assert "state: myxo-abort" in content, "Workflow should reference the myxo-abort label"
 
 
 def test_uses_env_for_issue_data():


### PR DESCRIPTION
## Summary
Rename worker agent terminology from "pseudopod" to "myxo" to align with the Lab metaphor reorganization. Also renames Scribe→Report and FieldNote→BenchNote in README.

Changes:
- `_SUBDIRS` in cli.py: `pseudopods` → `myxos`
- `.myxo/pseudopods/` → `.myxo/myxos/` (git mv)
- Pulumi labels: `state: pseudopod-*` → `state: myxo-*`
- Workflow: all `pseudopod` label references → `myxo`
- README: terminology table, Mermaid diagram, metaphor text
- Commit-rules skill: example text

Closes #154