### PR TITLE
test: 🧪 add pytest size markers and auto-marking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,4 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.13"
-      - run: uv run pytest
+      - run: uv run pytest -m "small or medium"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ packages = ["src/myxo"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "small: Fast unit tests (no network, no disk beyond tmp_path, no DB)",
+    "medium: Integration tests (may use network, disk, or local services)",
+    "large: End-to-end / system tests (external services, long-running)",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared pytest configuration and fixtures."""
+
+import pytest
+
+# Marker names used for test sizing
+SIZE_MARKERS = {"small", "medium", "large"}
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-apply ``@pytest.mark.small`` to tests that have no size marker.
+
+    This ensures every test is categorized, so ``-m small`` collects all
+    unmarked (i.e. fast unit) tests without requiring explicit decoration.
+    """
+    for item in items:
+        existing = {m.name for m in item.iter_markers()}
+        if not existing & SIZE_MARKERS:
+            item.add_marker(pytest.mark.small)

--- a/tests/test_pytest_markers.py
+++ b/tests/test_pytest_markers.py
@@ -1,0 +1,114 @@
+"""Tests for pytest marker configuration (small/medium/large)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+CONFTEST = Path(__file__).parent / "conftest.py"
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+class TestMarkerRegistration:
+    """Verify that small/medium/large markers are registered in pytest."""
+
+    def test_small_marker_registered(self):
+        """pytest --markers should list the 'small' marker."""
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "--markers"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        assert "@pytest.mark.small" in result.stdout
+
+    def test_medium_marker_registered(self):
+        """pytest --markers should list the 'medium' marker."""
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "--markers"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        assert "@pytest.mark.medium" in result.stdout
+
+    def test_large_marker_registered(self):
+        """pytest --markers should list the 'large' marker."""
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "--markers"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        assert "@pytest.mark.large" in result.stdout
+
+
+class TestPyprojectMarkerConfig:
+    """Verify pyproject.toml contains marker definitions."""
+
+    def test_markers_defined_in_pyproject(self):
+        """pyproject.toml should define markers under [tool.pytest.ini_options]."""
+        content = PYPROJECT.read_text()
+        assert "markers" in content
+        assert "small" in content
+        assert "medium" in content
+        assert "large" in content
+
+
+class TestConftestExists:
+    """Verify conftest.py exists with marker-related configuration."""
+
+    def test_conftest_exists(self):
+        """tests/conftest.py should exist."""
+        assert CONFTEST.is_file(), f"Expected conftest.py at {CONFTEST}"
+
+    def test_conftest_has_auto_mark_logic(self):
+        """conftest.py should contain logic to auto-apply 'small' marker to unmarked tests."""
+        content = CONFTEST.read_text()
+        # Should reference the marker names for auto-marking
+        assert "small" in content
+        assert "medium" in content
+        assert "large" in content
+
+
+class TestDefaultMarkerBehavior:
+    """Verify unmarked tests automatically receive the 'small' marker."""
+
+    def test_unmarked_test_gets_small_marker(self):
+        """A test without any size marker should be collected when running -m small."""
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "--collect-only", "-m", "small", "-q"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        assert result.returncode == 0
+        # Should collect tests (unmarked tests should be included as 'small')
+        assert "no tests ran" not in result.stdout.lower()
+        assert "test_cli.py" in result.stdout or "test_" in result.stdout
+
+    def test_unmarked_test_excluded_from_large(self):
+        """Unmarked tests should NOT be collected when running -m large."""
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "--collect-only", "-m", "large", "-q"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+        )
+        # Should collect 0 tests (no tests are explicitly marked large)
+        output = result.stdout.lower()
+        assert "no tests collected" in output or "no tests ran" in output or "0 selected" in output
+
+
+class TestCIConfiguration:
+    """Verify CI workflow runs only small and medium tests by default."""
+
+    def test_lint_yml_uses_marker_filter(self):
+        """The test job in lint.yml should filter by small/medium markers."""
+        lint_yml = ROOT / ".github" / "workflows" / "lint.yml"
+        assert lint_yml.is_file(), "lint.yml should exist"
+        content = lint_yml.read_text()
+        # Should use -m flag to select small and medium tests
+        assert "-m" in content
+        assert "small" in content
+        assert "medium" in content


### PR DESCRIPTION
## Summary
- Define `small`, `medium`, `large` pytest markers in `pyproject.toml`
- Add `tests/conftest.py` with auto-marking logic that applies `@pytest.mark.small` to unmarked tests
- Update CI test job to run only `small` and `medium` tests by default (`-m "small or medium"`)
- Add `tests/test_pytest_markers.py` verifying marker registration, auto-marking behavior, and CI config

Refs #134