### PR TITLE
chore: ⬆️ bump GitHub Actions versions and disable Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "develop"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "develop"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,8 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
           enable-cache: true
@@ -25,8 +25,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
           enable-cache: true
@@ -35,8 +35,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
           enable-cache: true

--- a/.github/workflows/myxo-procedure.yml
+++ b/.github/workflows/myxo-procedure.yml
@@ -25,9 +25,9 @@ jobs:
             --remove-label "state: myxo-ready" \
             --add-label "state: myxo-active"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -8,8 +8,8 @@ jobs:
   lint-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
       - env:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
+          enable-cache: false
       - env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: python .github/scripts/pr-title-lint.py "$PR_TITLE"

--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -14,9 +14,9 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
           enable-cache: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ jobs:
     name: Gitleaks secret scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -73,9 +73,9 @@ def test_schedule_interval_defined():
 
 
 def test_open_pull_requests_limit():
-    """All ecosystems should limit open PRs to 5."""
+    """All ecosystems should disable PR creation (alerts only)."""
     data = yaml.safe_load(DEPENDABOT_PATH.read_text())
     for entry in data["updates"]:
-        assert entry.get("open-pull-requests-limit") == 5, (
-            f"Ecosystem {entry.get('package-ecosystem')} should limit open PRs to 5"
+        assert entry.get("open-pull-requests-limit") == 0, (
+            f"Ecosystem {entry.get('package-ecosystem')} should have open-pull-requests-limit: 0"
         )


### PR DESCRIPTION
## Summary
Apply Dependabot-suggested version bumps manually and disable Dependabot PR creation:

- `actions/checkout` v4 → v6 (all 5 workflows)
- `astral-sh/setup-uv` v6 → v7 (3 workflows)
- `actions/setup-python` v5 → v6 (myxo-procedure.yml)
- Set `open-pull-requests-limit: 0` to use Dependabot alerts only (no PRs)

Supersedes #163, #164, #165