### PR TITLE
feat: ✨ define ECS Fargate infrastructure with Pulumi

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -1,3 +1,4 @@
 config:
+  aws:region: ap-northeast-1
   github:owner: June3141
   myxo-lab:repo: myxo-lab

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -3,6 +3,8 @@
 import pulumi
 import pulumi_github as github
 
+import infra.ecs  # noqa: F401 — ECS Fargate resources
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -3,7 +3,7 @@
 import pulumi
 import pulumi_github as github
 
-import infra.ecs  # noqa: F401 — ECS Fargate resources
+import ecs  # noqa: F401 — ECS Fargate resources (Pulumi runs from infra/ directory)
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/infra/ecs.py
+++ b/infra/ecs.py
@@ -11,6 +11,9 @@ import json
 import pulumi
 import pulumi_aws as aws
 
+config = pulumi.Config("aws")
+_region = config.require("region")
+
 # --- providers ---------------------------------------------------------------
 ecs = aws.ecs
 ecr = aws.ecr
@@ -29,7 +32,7 @@ repo = ecr.Repository(
     "myxo-base-repo",
     name="myxo-base",
     image_tag_mutability="MUTABLE",
-    force_delete=True,  # PoC convenience — remove in production
+    force_delete=False,
 )
 
 # --- ECS Cluster -------------------------------------------------------------
@@ -103,7 +106,7 @@ task_definition = ecs.TaskDefinition(
                         "logDriver": "awslogs",
                         "options": {
                             "awslogs-group": args[1],
-                            "awslogs-region": aws.get_region().name,
+                            "awslogs-region": _region,
                             "awslogs-stream-prefix": "myxo",
                         },
                     },

--- a/infra/ecs.py
+++ b/infra/ecs.py
@@ -1,0 +1,119 @@
+"""ECS Fargate resources for Myxo execution environment (PoC).
+
+Defines minimal ECS infrastructure:
+- ECS Cluster, ECR Repository, CloudWatch Log Group
+- IAM roles (task execution + task)
+- Fargate Task Definition (0.25 vCPU / 512 MB)
+"""
+
+import json
+
+import pulumi
+import pulumi_aws as aws
+
+# --- providers ---------------------------------------------------------------
+ecs = aws.ecs
+ecr = aws.ecr
+iam = aws.iam
+cloudwatch = aws.cloudwatch
+
+# --- CloudWatch Log Group ----------------------------------------------------
+log_group = cloudwatch.LogGroup(
+    "myxo-log-group",
+    name="/ecs/myxo",
+    retention_in_days=14,
+)
+
+# --- ECR Repository ----------------------------------------------------------
+repo = ecr.Repository(
+    "myxo-base-repo",
+    name="myxo-base",
+    image_tag_mutability="MUTABLE",
+    force_delete=True,  # PoC convenience — remove in production
+)
+
+# --- ECS Cluster -------------------------------------------------------------
+cluster = ecs.Cluster(
+    "myxo-cluster",
+    name="myxo-cluster",
+)
+
+# --- IAM: Task Execution Role -----------------------------------------------
+task_execution_role = iam.Role(
+    "myxo-task-execution-role",
+    name="myxo-task-execution-role",
+    assume_role_policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    ),
+)
+
+iam.RolePolicyAttachment(
+    "myxo-exec-policy",
+    role=task_execution_role.name,
+    policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+)
+
+# --- IAM: Task Role (placeholder for Secrets Manager / S3) -------------------
+task_role = iam.Role(
+    "myxo-task-role",
+    name="myxo-task-role",
+    assume_role_policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    ),
+)
+
+# --- ECS Task Definition -----------------------------------------------------
+task_definition = ecs.TaskDefinition(
+    "myxo-task",
+    family="myxo-task",
+    cpu="256",
+    memory="512",
+    network_mode="awsvpc",
+    requires_compatibilities=["FARGATE"],
+    execution_role_arn=task_execution_role.arn,
+    task_role_arn=task_role.arn,
+    container_definitions=pulumi.Output.all(repo.repository_url, log_group.name).apply(
+        lambda args: json.dumps(
+            [
+                {
+                    "name": "myxo",
+                    "image": f"{args[0]}:latest",
+                    "cpu": 256,
+                    "memory": 512,
+                    "essential": True,
+                    "logConfiguration": {
+                        "logDriver": "awslogs",
+                        "options": {
+                            "awslogs-group": args[1],
+                            "awslogs-region": aws.get_region().name,
+                            "awslogs-stream-prefix": "myxo",
+                        },
+                    },
+                }
+            ]
+        )
+    ),
+)
+
+# --- Exports -----------------------------------------------------------------
+pulumi.export("cluster_name", cluster.name)
+pulumi.export("ecr_url", repo.repository_url)
+pulumi.export("task_definition_arn", task_definition.arn)

--- a/tests/test_ecs_infra.py
+++ b/tests/test_ecs_infra.py
@@ -51,12 +51,8 @@ def test_defines_iam_roles():
     """ecs.py must define IAM roles for task execution and task."""
     src = _ecs_source()
     assert "iam.Role(" in src, "ecs.py must define iam.Role"
-    assert "task_execution_role" in src or "task-execution-role" in src, (
-        "ecs.py must define a task execution role"
-    )
-    assert "task_role" in src or "task-role" in src, (
-        "ecs.py must define a task role"
-    )
+    assert "task_execution_role" in src or "task-execution-role" in src, "ecs.py must define a task execution role"
+    assert "task_role" in src or "task-role" in src, "ecs.py must define a task role"
 
 
 def test_defines_cloudwatch_log_group():
@@ -73,9 +69,7 @@ def test_defines_cloudwatch_log_group():
 def test_no_pseudopod_references():
     """All resource names must use 'myxo', not 'pseudopod'."""
     src = _ecs_source()
-    assert "pseudopod" not in src.lower(), (
-        "ecs.py must not reference 'pseudopod' — use 'myxo' instead"
-    )
+    assert "pseudopod" not in src.lower(), "ecs.py must not reference 'pseudopod' — use 'myxo' instead"
 
 
 def test_myxo_naming():
@@ -94,9 +88,7 @@ def test_myxo_naming():
 def test_main_imports_ecs_module():
     """__main__.py must import or reference the ECS module."""
     main_src = (INFRA_DIR / "__main__.py").read_text()
-    assert "ecs" in main_src.lower(), (
-        "__main__.py must import or reference the ECS module"
-    )
+    assert "ecs" in main_src.lower(), "__main__.py must import or reference the ECS module"
 
 
 # ---------------------------------------------------------------------------
@@ -108,12 +100,6 @@ def test_exports_key_outputs():
     """ecs.py must export cluster name, ECR URL, and task definition ARN."""
     src = _ecs_source()
     assert "pulumi.export(" in src, "ecs.py must export Pulumi outputs"
-    assert "cluster" in src.lower() and "export" in src.lower(), (
-        "ecs.py must export cluster-related output"
-    )
-    assert "ecr" in src.lower() and "url" in src.lower(), (
-        "ecs.py must export ECR URL"
-    )
-    assert "task" in src.lower() and "arn" in src.lower(), (
-        "ecs.py must export task definition ARN"
-    )
+    assert "cluster" in src.lower() and "export" in src.lower(), "ecs.py must export cluster-related output"
+    assert "ecr" in src.lower() and "url" in src.lower(), "ecs.py must export ECR URL"
+    assert "task" in src.lower() and "arn" in src.lower(), "ecs.py must export task definition ARN"

--- a/tests/test_ecs_infra.py
+++ b/tests/test_ecs_infra.py
@@ -1,0 +1,119 @@
+"""ECS Fargate infrastructure source-level tests.
+
+Since we cannot run ``pulumi up`` in CI, these tests validate that the
+infrastructure source code defines the expected AWS resources using
+"myxo" naming throughout.
+"""
+
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+
+
+# ---------------------------------------------------------------------------
+# Module existence
+# ---------------------------------------------------------------------------
+
+
+def test_ecs_module_exists():
+    """infra/ecs.py must exist."""
+    assert (INFRA_DIR / "ecs.py").is_file(), "infra/ecs.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Resource definitions in ecs.py
+# ---------------------------------------------------------------------------
+
+
+def _ecs_source() -> str:
+    return (INFRA_DIR / "ecs.py").read_text()
+
+
+def test_defines_ecs_cluster():
+    """ecs.py must define an ECS Cluster resource."""
+    src = _ecs_source()
+    assert "ecs.Cluster(" in src, "ecs.py must define ecs.Cluster"
+
+
+def test_defines_ecr_repository():
+    """ecs.py must define an ECR Repository resource."""
+    src = _ecs_source()
+    assert "ecr.Repository(" in src, "ecs.py must define ecr.Repository"
+
+
+def test_defines_task_definition():
+    """ecs.py must define an ECS Task Definition resource."""
+    src = _ecs_source()
+    assert "ecs.TaskDefinition(" in src, "ecs.py must define ecs.TaskDefinition"
+
+
+def test_defines_iam_roles():
+    """ecs.py must define IAM roles for task execution and task."""
+    src = _ecs_source()
+    assert "iam.Role(" in src, "ecs.py must define iam.Role"
+    assert "task_execution_role" in src or "task-execution-role" in src, (
+        "ecs.py must define a task execution role"
+    )
+    assert "task_role" in src or "task-role" in src, (
+        "ecs.py must define a task role"
+    )
+
+
+def test_defines_cloudwatch_log_group():
+    """ecs.py must define a CloudWatch Log Group."""
+    src = _ecs_source()
+    assert "cloudwatch.LogGroup(" in src, "ecs.py must define cloudwatch.LogGroup"
+
+
+# ---------------------------------------------------------------------------
+# Naming convention — "myxo" not "pseudopod"
+# ---------------------------------------------------------------------------
+
+
+def test_no_pseudopod_references():
+    """All resource names must use 'myxo', not 'pseudopod'."""
+    src = _ecs_source()
+    assert "pseudopod" not in src.lower(), (
+        "ecs.py must not reference 'pseudopod' — use 'myxo' instead"
+    )
+
+
+def test_myxo_naming():
+    """Key resources must include 'myxo' in their names."""
+    src = _ecs_source()
+    assert "myxo-cluster" in src, "ECS cluster must be named 'myxo-cluster'"
+    assert "myxo-base" in src, "ECR repository must be named 'myxo-base'"
+    assert "/ecs/myxo" in src, "CloudWatch log group must be '/ecs/myxo'"
+
+
+# ---------------------------------------------------------------------------
+# __main__.py imports ECS module
+# ---------------------------------------------------------------------------
+
+
+def test_main_imports_ecs_module():
+    """__main__.py must import or reference the ECS module."""
+    main_src = (INFRA_DIR / "__main__.py").read_text()
+    assert "ecs" in main_src.lower(), (
+        "__main__.py must import or reference the ECS module"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
+
+def test_exports_key_outputs():
+    """ecs.py must export cluster name, ECR URL, and task definition ARN."""
+    src = _ecs_source()
+    assert "pulumi.export(" in src, "ecs.py must export Pulumi outputs"
+    assert "cluster" in src.lower() and "export" in src.lower(), (
+        "ecs.py must export cluster-related output"
+    )
+    assert "ecr" in src.lower() and "url" in src.lower(), (
+        "ecs.py must export ECR URL"
+    )
+    assert "task" in src.lower() and "arn" in src.lower(), (
+        "ecs.py must export task definition ARN"
+    )


### PR DESCRIPTION
## Summary
- Add infra/ecs.py with minimal PoC ECS Fargate resources: Cluster (myxo-cluster), ECR Repository (myxo-base), CloudWatch Log Group (/ecs/myxo), IAM execution/task roles, and Task Definition (0.25 vCPU / 512 MB)
- Wire ECS module into infra/__main__.py and add aws:region to Pulumi.dev.yaml
- Add source-level tests in tests/test_ecs_infra.py validating all resource definitions and myxo naming

> **Note:** pulumi_aws is NOT added to pyproject.toml — it should be installed in the infra-specific venv managed by Pulumi (too heavy for the main project).

Closes #136