### PR TITLE
docs: 📝 rename metaphor terms per 4-layer model

### DIFF
--- a/.claude/skills/commit-rules/SKILL.md
+++ b/.claude/skills/commit-rules/SKILL.md
@@ -75,7 +75,7 @@ Commonly used:
 feat: ✨ add hypothesis tracking endpoint
 
 The /hypotheses endpoint enables tracking of active experiments.
-This will be used by the Protocol agent for task decomposition.
+This will be used by the Fellow agent for task decomposition.
 ```
 
 ```

--- a/.claude/skills/pr-rules/SKILL.md
+++ b/.claude/skills/pr-rules/SKILL.md
@@ -71,7 +71,7 @@ Assign the appropriate milestone based on the issue being closed:
 | Milestone | When |
 |-----------|------|
 | `Phase 1: PoC` | Foundation, CLI, Pulumi, GitHub Actions, MCP, security |
-| `Phase 2: 本番化` | Temporal, Protocol/Assay agents, GitHub App |
+| `Phase 2: 本番化` | Temporal, Fellow/Microscope agents, GitHub App |
 | `Phase 3: 拡張` | OSS release, cost monitoring, auto-rollback |
 
 ## Assignee

--- a/README.md
+++ b/README.md
@@ -18,34 +18,49 @@
 
 ---
 
-Myxo `/ˈmɪk.soʊ/` orchestrates AI coding agents through a laboratory-experiment metaphor: a **Researcher** designs hypotheses, **Protocols** decompose them into steps, and **Myxos** (worker agents) explore and implement solutions — all verified by rigorous **Assays** before **Publication**.
+Myxo `/ˈmɪk.soʊ/` orchestrates AI coding agents through a laboratory-experiment metaphor: a **Researcher** designs hypotheses, **Fellows** decompose them into steps, and **Myxos** (worker agents) explore and implement solutions — all verified by rigorous **Microscope** analysis before **Publication**.
 
 ---
 
 ## Terminology
 
-Myxo uses a naming convention drawn from slime mold biology and experimental science.
+Myxo uses a naming convention drawn from slime mold biology and experimental science, organized into a **4-layer model**.
 
-### Roles
+### 4-Layer Model
+
+| Layer | What it represents | Examples |
+|-------|--------------------|----------|
+| **Person** | Human or autonomous agents with intent | Researcher, Fellow, Myxo |
+| **Device** | Tools and instruments agents use | Microscope, Recorder |
+| **Artifact** | Documents, data, and work products | Hypothesis, Protocol, Experiment, PeerReview |
+| **Environment** | Where work happens and memory lives | Petri, Publication, LabNote, BenchNote |
+
+### Person Layer
 
 | Role | Pronunciation | Description |
 |------|---------------|-------------|
 | **Researcher** | — | The human operator. Designs experiments and makes final decisions. |
-| **Protocol** | — | The director agent. Decomposes a Hypothesis into parallel tasks and assigns them to Myxos. |
+| **Fellow** | — | The director agent. Decomposes a Hypothesis into parallel tasks and assigns them to Myxos. |
 | **Myxo** | `/ˈmɪk.soʊ/` | Worker agents — the cultured slime molds that explore the environment and bring results back. |
-| **Assay** | `/ˈæs.eɪ/` | The reviewer agent. Performs quality analysis on Myxo output, including code review and risk evaluation. |
-| **Report** | — | The explainer agent. Generates documentation and summaries of changes (experiment reports). |
 
-### Concepts
+### Device Layer
 
-| Concept | Pronunciation | Description |
-|---------|---------------|-------------|
+| Device | Description |
+|--------|-------------|
+| **Microscope** | The reviewer instrument. Performs quality analysis on Myxo output, including code review and risk evaluation. |
+| **Recorder** | The documentation instrument. Generates summaries of changes (experiment reports). |
+
+### Artifact Layer
+
+| Artifact | Pronunciation | Description |
+|----------|---------------|-------------|
 | **Hypothesis** | — | A task definition (GitHub Issue). "We hypothesize this can be solved." |
+| **Protocol** | — | A procedure document defining workflow steps. Stored in `.myxo-lab/protocols/`. |
 | **Procedure** | — | A workflow definition executed in Temporal. The concrete steps to test a Hypothesis. |
 | **PeerReview** | — | The merge-decision evaluator. Classifies PRs as `AUTO_MERGE`, `HUMAN_SUGGESTED`, or `HUMAN_REQUIRED`. |
 | **Experiment** | — | A unit of work. A Hypothesis being actively tested. |
 
-### Environments & Memory
+### Environment Layer
 
 | Name | Pronunciation | Description |
 |------|---------------|-------------|
@@ -67,12 +82,12 @@ How a Hypothesis travels from idea to production.
 flowchart TD
     R["🧑‍🔬 Researcher (Human)"]
     H["📋 Hypothesis (GitHub Issue)"]
-    P["🧪 Protocol"]
+    P["🧑‍🔬 Fellow"]
     LN[("📓 LabNote\n(shared memory)")]
     P1["🦠 Myxo"]
     P2["🦠 Myxo"]
     P3["🦠 ···"]
-    A["🔬 Assay"]
+    A["🔬 Microscope"]
     PR["📊 PeerReview"]
     PUB["🌐 Publication"]
     RN["🔔 Researcher\nnotification"]

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -23,7 +23,7 @@ class TestDeprecatedAgentNames:
     @pytest.mark.small
     def test_readme_no_assay_as_agent(self):
         """Assay (agent) should be renamed to Microscope in README."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         # "Assay" should not appear as a role/agent name
         assert "**Assay**" not in content
         assert "Assay" not in content
@@ -31,14 +31,14 @@ class TestDeprecatedAgentNames:
     @pytest.mark.small
     def test_readme_no_report_as_agent(self):
         """Report (agent) should be renamed to Recorder in README."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         # "Report" as an agent role should not appear
         assert "**Report**" not in content
 
     @pytest.mark.small
     def test_readme_no_scribe_as_agent(self):
         """Scribe should not appear anywhere in README."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "Scribe" not in content
 
     @pytest.mark.small
@@ -46,7 +46,7 @@ class TestDeprecatedAgentNames:
         """Assay agent name should not appear in skill docs."""
         skills_dir = ROOT / ".claude" / "skills"
         for md_file in skills_dir.rglob("*.md"):
-            content = md_file.read_text()
+            content = md_file.read_text(encoding="utf-8")
             # "Assay" as agent reference should be replaced with Microscope
             assert "Assay" not in content, f"Found deprecated 'Assay' in {md_file.relative_to(ROOT)}"
 
@@ -60,25 +60,25 @@ class TestNewAgentNames:
     @pytest.mark.small
     def test_readme_has_microscope_role(self):
         """Microscope should appear as a role in README."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "**Microscope**" in content
 
     @pytest.mark.small
     def test_readme_has_recorder_role(self):
         """Recorder should appear as a role in README."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "**Recorder**" in content
 
     @pytest.mark.small
     def test_readme_has_fellow_role(self):
         """Fellow should appear as a role in README."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "**Fellow**" in content
 
     @pytest.mark.small
     def test_readme_protocol_still_exists_as_artifact(self):
         """Protocol should still exist as an artifact/document concept."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "Protocol" in content
 
 
@@ -90,22 +90,22 @@ class TestFourLayerModel:
 
     @pytest.mark.small
     def test_readme_has_person_layer(self):
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "Person" in content
 
     @pytest.mark.small
     def test_readme_has_device_layer(self):
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "Device" in content
 
     @pytest.mark.small
     def test_readme_has_artifact_layer(self):
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "Artifact" in content
 
     @pytest.mark.small
     def test_readme_has_environment_layer(self):
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         # "Environment" already in the section header
         assert "Environment" in content
 
@@ -119,7 +119,7 @@ class TestMermaidDiagram:
     @pytest.mark.small
     def test_mermaid_uses_fellow_not_protocol(self):
         """In the execution flow, the director agent should be Fellow."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "Fellow" in content
         # The old Protocol agent label in Mermaid should be gone
         assert "🧪 Protocol" not in content
@@ -127,7 +127,7 @@ class TestMermaidDiagram:
     @pytest.mark.small
     def test_mermaid_uses_microscope_not_assay(self):
         """In the execution flow, the reviewer agent should be Microscope."""
-        content = (ROOT / "README.md").read_text()
+        content = (ROOT / "README.md").read_text(encoding="utf-8")
         assert "Microscope" in content
         assert "🔬 Assay" not in content
 
@@ -140,15 +140,15 @@ class TestSkillDocsUpdated:
 
     @pytest.mark.small
     def test_pr_rules_uses_fellow(self):
-        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text()
+        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text(encoding="utf-8")
         assert "Fellow" in content
 
     @pytest.mark.small
     def test_pr_rules_uses_microscope(self):
-        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text()
+        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text(encoding="utf-8")
         assert "Microscope" in content
 
     @pytest.mark.small
     def test_commit_rules_uses_fellow(self):
-        content = (ROOT / ".claude" / "skills" / "commit-rules" / "SKILL.md").read_text()
+        content = (ROOT / ".claude" / "skills" / "commit-rules" / "SKILL.md").read_text(encoding="utf-8")
         assert "Fellow" in content

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -48,9 +48,7 @@ class TestDeprecatedAgentNames:
         for md_file in skills_dir.rglob("*.md"):
             content = md_file.read_text()
             # "Assay" as agent reference should be replaced with Microscope
-            assert "Assay" not in content, (
-                f"Found deprecated 'Assay' in {md_file.relative_to(ROOT)}"
-            )
+            assert "Assay" not in content, f"Found deprecated 'Assay' in {md_file.relative_to(ROOT)}"
 
 
 # --- New term presence ---
@@ -124,14 +122,14 @@ class TestMermaidDiagram:
         content = (ROOT / "README.md").read_text()
         assert "Fellow" in content
         # The old Protocol agent label in Mermaid should be gone
-        assert '🧪 Protocol' not in content
+        assert "🧪 Protocol" not in content
 
     @pytest.mark.small
     def test_mermaid_uses_microscope_not_assay(self):
         """In the execution flow, the reviewer agent should be Microscope."""
         content = (ROOT / "README.md").read_text()
         assert "Microscope" in content
-        assert '🔬 Assay' not in content
+        assert "🔬 Assay" not in content
 
 
 # --- Skill docs updated ---
@@ -142,21 +140,15 @@ class TestSkillDocsUpdated:
 
     @pytest.mark.small
     def test_pr_rules_uses_fellow(self):
-        content = (
-            ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md"
-        ).read_text()
+        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text()
         assert "Fellow" in content
 
     @pytest.mark.small
     def test_pr_rules_uses_microscope(self):
-        content = (
-            ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md"
-        ).read_text()
+        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text()
         assert "Microscope" in content
 
     @pytest.mark.small
     def test_commit_rules_uses_fellow(self):
-        content = (
-            ROOT / ".claude" / "skills" / "commit-rules" / "SKILL.md"
-        ).read_text()
+        content = (ROOT / ".claude" / "skills" / "commit-rules" / "SKILL.md").read_text()
         assert "Fellow" in content

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -1,0 +1,162 @@
+"""Tests for 4-layer model terminology in project documentation.
+
+Verifies that the metaphor terms follow the 4-layer model:
+- Person layer: Researcher, Fellow (was Protocol-as-agent)
+- Device layer: Microscope (was Assay), Recorder (was Report/Scribe)
+- Artifact layer: Hypothesis, Protocol (document), Experiment, etc.
+- Environment layer: Petri, Publication, LabNote, etc.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+# --- Deprecated term detection ---
+
+
+class TestDeprecatedAgentNames:
+    """Ensure deprecated agent names are no longer used."""
+
+    @pytest.mark.small
+    def test_readme_no_assay_as_agent(self):
+        """Assay (agent) should be renamed to Microscope in README."""
+        content = (ROOT / "README.md").read_text()
+        # "Assay" should not appear as a role/agent name
+        assert "**Assay**" not in content
+        assert "Assay" not in content
+
+    @pytest.mark.small
+    def test_readme_no_report_as_agent(self):
+        """Report (agent) should be renamed to Recorder in README."""
+        content = (ROOT / "README.md").read_text()
+        # "Report" as an agent role should not appear
+        assert "**Report**" not in content
+
+    @pytest.mark.small
+    def test_readme_no_scribe_as_agent(self):
+        """Scribe should not appear anywhere in README."""
+        content = (ROOT / "README.md").read_text()
+        assert "Scribe" not in content
+
+    @pytest.mark.small
+    def test_skill_docs_no_assay_as_agent(self):
+        """Assay agent name should not appear in skill docs."""
+        skills_dir = ROOT / ".claude" / "skills"
+        for md_file in skills_dir.rglob("*.md"):
+            content = md_file.read_text()
+            # "Assay" as agent reference should be replaced with Microscope
+            assert "Assay" not in content, (
+                f"Found deprecated 'Assay' in {md_file.relative_to(ROOT)}"
+            )
+
+
+# --- New term presence ---
+
+
+class TestNewAgentNames:
+    """Ensure the new 4-layer model agent names are present."""
+
+    @pytest.mark.small
+    def test_readme_has_microscope_role(self):
+        """Microscope should appear as a role in README."""
+        content = (ROOT / "README.md").read_text()
+        assert "**Microscope**" in content
+
+    @pytest.mark.small
+    def test_readme_has_recorder_role(self):
+        """Recorder should appear as a role in README."""
+        content = (ROOT / "README.md").read_text()
+        assert "**Recorder**" in content
+
+    @pytest.mark.small
+    def test_readme_has_fellow_role(self):
+        """Fellow should appear as a role in README."""
+        content = (ROOT / "README.md").read_text()
+        assert "**Fellow**" in content
+
+    @pytest.mark.small
+    def test_readme_protocol_still_exists_as_artifact(self):
+        """Protocol should still exist as an artifact/document concept."""
+        content = (ROOT / "README.md").read_text()
+        assert "Protocol" in content
+
+
+# --- 4-Layer model ---
+
+
+class TestFourLayerModel:
+    """Ensure the 4-layer model is documented in README."""
+
+    @pytest.mark.small
+    def test_readme_has_person_layer(self):
+        content = (ROOT / "README.md").read_text()
+        assert "Person" in content
+
+    @pytest.mark.small
+    def test_readme_has_device_layer(self):
+        content = (ROOT / "README.md").read_text()
+        assert "Device" in content
+
+    @pytest.mark.small
+    def test_readme_has_artifact_layer(self):
+        content = (ROOT / "README.md").read_text()
+        assert "Artifact" in content
+
+    @pytest.mark.small
+    def test_readme_has_environment_layer(self):
+        content = (ROOT / "README.md").read_text()
+        # "Environment" already in the section header
+        assert "Environment" in content
+
+
+# --- Mermaid diagram ---
+
+
+class TestMermaidDiagram:
+    """Ensure Mermaid diagram uses new terminology."""
+
+    @pytest.mark.small
+    def test_mermaid_uses_fellow_not_protocol(self):
+        """In the execution flow, the director agent should be Fellow."""
+        content = (ROOT / "README.md").read_text()
+        assert "Fellow" in content
+        # The old Protocol agent label in Mermaid should be gone
+        assert '🧪 Protocol' not in content
+
+    @pytest.mark.small
+    def test_mermaid_uses_microscope_not_assay(self):
+        """In the execution flow, the reviewer agent should be Microscope."""
+        content = (ROOT / "README.md").read_text()
+        assert "Microscope" in content
+        assert '🔬 Assay' not in content
+
+
+# --- Skill docs updated ---
+
+
+class TestSkillDocsUpdated:
+    """Ensure skill docs use new terminology."""
+
+    @pytest.mark.small
+    def test_pr_rules_uses_fellow(self):
+        content = (
+            ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md"
+        ).read_text()
+        assert "Fellow" in content
+
+    @pytest.mark.small
+    def test_pr_rules_uses_microscope(self):
+        content = (
+            ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md"
+        ).read_text()
+        assert "Microscope" in content
+
+    @pytest.mark.small
+    def test_commit_rules_uses_fellow(self):
+        content = (
+            ROOT / ".claude" / "skills" / "commit-rules" / "SKILL.md"
+        ).read_text()
+        assert "Fellow" in content


### PR DESCRIPTION
## Summary
Rename agent terminology across project documentation to follow the 4-layer model: Assay becomes Microscope (Device), Report becomes Recorder (Device), Protocol-as-agent becomes Fellow (Person). Protocol-as-document remains unchanged. Adds 4-layer model table (Person, Device, Artifact, Environment) to README.

Closes #173