### PR TITLE
feat: ✨ add label-based Kanban auto-move workflow

### DIFF
--- a/.github/workflows/kanban-sync.yml
+++ b/.github/workflows/kanban-sync.yml
@@ -1,0 +1,78 @@
+name: Kanban Sync
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: read
+  repository-projects: write
+
+jobs:
+  move-card:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine target column
+        id: column
+        env:
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          case "${LABEL_NAME}" in
+            "state: myxo-ready")     echo "column=Ready"       >> "$GITHUB_OUTPUT" ;;
+            "state: myxo-active")    echo "column=In Progress"  >> "$GITHUB_OUTPUT" ;;
+            "state: myxo-abort")     echo "column=Blocked"      >> "$GITHUB_OUTPUT" ;;
+            "state: myxo-complete")  echo "column=Review"       >> "$GITHUB_OUTPUT" ;;
+            "state: researcher-review") echo "column=Review"    >> "$GITHUB_OUTPUT" ;;
+            *)                       echo "column="             >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Move issue on project board
+        if: steps.column.outputs.column != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TARGET_COLUMN: ${{ steps.column.outputs.column }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          PROJECT_NUMBER=$(gh project list --owner "${REPO_OWNER}" --format json \
+            | jq -r '.projects[0].number // empty')
+
+          if [ -z "${PROJECT_NUMBER}" ]; then
+            echo "::warning::No project board found for owner ${REPO_OWNER}. Skipping."
+            exit 0
+          fi
+
+          ITEM_ID=$(gh project item-list "${PROJECT_NUMBER}" \
+            --owner "${REPO_OWNER}" --format json \
+            | jq -r --arg num "${ISSUE_NUMBER}" --arg repo "${REPO_NAME}" \
+              '.items[] | select(.content.number == ($num | tonumber) and .content.repository == $repo) | .id // empty')
+
+          if [ -z "${ITEM_ID}" ]; then
+            echo "::warning::Issue #${ISSUE_NUMBER} is not on project board ${PROJECT_NUMBER}. Skipping."
+            exit 0
+          fi
+
+          FIELD_ID=$(gh project field-list "${PROJECT_NUMBER}" \
+            --owner "${REPO_OWNER}" --format json \
+            | jq -r 'first(.fields[] | select(.name == "Status")) | .id')
+          OPTION_ID=$(gh project field-list "${PROJECT_NUMBER}" \
+            --owner "${REPO_OWNER}" --format json \
+            | jq -r --arg col "${TARGET_COLUMN}" \
+              'first(.fields[] | select(.name == "Status")) | .options[] | select(.name == $col) | .id')
+
+          if [ -z "${FIELD_ID}" ] || [ -z "${OPTION_ID}" ]; then
+            echo "::warning::Could not find Status field or column '${TARGET_COLUMN}'. Skipping."
+            exit 0
+          fi
+
+          PROJECT_ID=$(gh project view "${PROJECT_NUMBER}" \
+            --owner "${REPO_OWNER}" --format json | jq -r '.id')
+
+          gh project item-edit \
+            --project-id "${PROJECT_ID}" \
+            --id "${ITEM_ID}" \
+            --field-id "${FIELD_ID}" \
+            --single-select-option-id "${OPTION_ID}"
+
+          echo "Moved issue #${ISSUE_NUMBER} to '${TARGET_COLUMN}' column."

--- a/tests/test_kanban_sync_workflow.py
+++ b/tests/test_kanban_sync_workflow.py
@@ -1,0 +1,68 @@
+"""Tests for kanban-sync GitHub Actions workflow."""
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "kanban-sync.yml"
+
+EXPECTED_LABELS = [
+    "state: myxo-ready",
+    "state: myxo-active",
+    "state: myxo-abort",
+    "state: myxo-complete",
+    "state: researcher-review",
+]
+
+
+def _load_workflow() -> dict:
+    """Load and parse the workflow YAML."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def test_workflow_file_exists():
+    """Workflow YAML file must exist."""
+    assert WORKFLOW_PATH.is_file(), f"{WORKFLOW_PATH} does not exist"
+
+
+def test_workflow_is_valid_yaml():
+    """Workflow file must be valid YAML that parses without error."""
+    data = _load_workflow()
+    assert isinstance(data, dict)
+
+
+def test_trigger_on_issues_labeled():
+    """Workflow must trigger on issues labeled event."""
+    data = _load_workflow()
+    triggers = data.get(True, data.get("on", {}))
+    issues_cfg = triggers.get("issues", {})
+    assert "labeled" in issues_cfg.get("types", [])
+
+
+def test_references_all_state_labels():
+    """Workflow must reference every expected state label."""
+    content = WORKFLOW_PATH.read_text()
+    for label in EXPECTED_LABELS:
+        assert label in content, f"Missing label reference: {label}"
+
+
+def test_has_permissions_block():
+    """Workflow must declare a permissions block."""
+    data = _load_workflow()
+    assert "permissions" in data, "Top-level permissions block missing"
+    perms = data["permissions"]
+    assert "issues" in perms
+    assert "repository-projects" in perms
+
+
+def test_no_expression_injection_in_run_blocks():
+    """Run blocks must not contain ${{ }} expressions (security)."""
+    data = _load_workflow()
+    jobs = data.get("jobs", {})
+    for job_name, job_cfg in jobs.items():
+        for step in job_cfg.get("steps", []):
+            run_block = step.get("run", "")
+            assert "${{" not in run_block, (
+                f"Expression injection risk in job '{job_name}', "
+                f"step '{step.get('name', '?')}': run block contains ${{{{ }}}}"
+            )


### PR DESCRIPTION
## Summary
- Add .github/workflows/kanban-sync.yml that triggers on issues labeled events
- Maps state labels (myxo-ready, myxo-active, myxo-abort, myxo-complete, researcher-review) to project board columns (Ready, In Progress, Blocked, Review)
- Uses env: blocks for all dynamic data to prevent expression injection in run: blocks
- Gracefully handles cases where the issue is not on a project board (warnings, no failures)
- Add tests/test_kanban_sync_workflow.py with 6 tests covering YAML validity, triggers, labels, permissions, and security

Closes #42