### PR TITLE
feat: ✨ create reusable GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,18 +9,13 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/lint.yml"
+      - ".github/workflows/reusable-python-ci.yml"
 
 jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.13"
-          enable-cache: true
-      - run: uv run ruff check src/ tests/
-      - run: uv run ruff format --check src/ tests/
+  ci:
+    uses: ./.github/workflows/reusable-python-ci.yml
+    with:
+      python-version: "3.13"
 
   typecheck:
     runs-on: ubuntu-latest
@@ -31,13 +26,3 @@ jobs:
           python-version: "3.13"
           enable-cache: true
       - run: uv run ty check src/
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.13"
-          enable-cache: true
-      - run: uv run pytest -m "small or medium"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
   ci:
     uses: ./.github/workflows/reusable-python-ci.yml
     with:
-      python-version: "3.13"
+      python_version: "3.13"
 
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -3,15 +3,15 @@ name: Reusable Python CI
 on:
   workflow_call:
     inputs:
-      python-version:
+      python_version:
         description: "Python version to use"
         type: string
         default: "3.13"
-      run-tests:
+      run_tests:
         description: "Whether to run pytest"
         type: boolean
         default: true
-      run-lint:
+      run_lint:
         description: "Whether to run ruff lint & format checks"
         type: boolean
         default: true
@@ -21,13 +21,13 @@ permissions:
 
 jobs:
   lint:
-    if: inputs.run-lint
+    if: inputs.run_lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: ${{ inputs.python_version }}
           enable-cache: true
       - name: Ruff check
         run: uv run ruff check src/ tests/
@@ -35,13 +35,13 @@ jobs:
         run: uv run ruff format --check src/ tests/
 
   test:
-    if: inputs.run-tests
+    if: inputs.run_tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: ${{ inputs.python_version }}
           enable-cache: true
       - name: Run tests
         run: uv run pytest -m "small or medium"

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -1,0 +1,47 @@
+name: Reusable Python CI
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to use"
+        type: string
+        default: "3.13"
+      run-tests:
+        description: "Whether to run pytest"
+        type: boolean
+        default: true
+      run-lint:
+        description: "Whether to run ruff lint & format checks"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    if: inputs.run-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+      - name: Ruff check
+        run: uv run ruff check src/ tests/
+      - name: Ruff format
+        run: uv run ruff format --check src/ tests/
+
+  test:
+    if: inputs.run-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+      - name: Run tests
+        run: uv run pytest -m "small or medium"

--- a/tests/test_pytest_markers.py
+++ b/tests/test_pytest_markers.py
@@ -103,11 +103,11 @@ class TestDefaultMarkerBehavior:
 class TestCIConfiguration:
     """Verify CI workflow runs only small and medium tests by default."""
 
-    def test_lint_yml_uses_marker_filter(self):
-        """The test job in lint.yml should filter by small/medium markers."""
-        lint_yml = ROOT / ".github" / "workflows" / "lint.yml"
-        assert lint_yml.is_file(), "lint.yml should exist"
-        content = lint_yml.read_text()
+    def test_ci_workflows_use_marker_filter(self):
+        """The reusable CI workflow should filter by small/medium markers."""
+        reusable = ROOT / ".github" / "workflows" / "reusable-python-ci.yml"
+        assert reusable.is_file(), "reusable-python-ci.yml should exist"
+        content = reusable.read_text()
         # Should use -m flag to select small and medium tests
         assert "-m" in content
         assert "small" in content

--- a/tests/test_shared_workflows.py
+++ b/tests/test_shared_workflows.py
@@ -1,0 +1,183 @@
+"""Tests for shared/reusable GitHub Actions workflows."""
+
+from pathlib import Path
+
+import yaml
+
+REUSABLE_CI_PATH = (
+    Path(__file__).parent.parent / ".github" / "workflows" / "reusable-python-ci.yml"
+)
+LINT_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "lint.yml"
+
+
+def _load_workflow(path: Path) -> dict:
+    """Load workflow YAML, handling 'on' key parsed as boolean True."""
+    return yaml.safe_load(path.read_text())
+
+
+def _get_on_block(data: dict) -> dict:
+    """Get the 'on' trigger block (YAML parses bare 'on' as True)."""
+    return data.get(True, data.get("on", {}))
+
+
+# ── reusable-python-ci.yml existence & validity ──
+
+
+def test_reusable_workflow_file_exists():
+    assert REUSABLE_CI_PATH.is_file(), "reusable-python-ci.yml must exist"
+
+
+def test_reusable_workflow_is_valid_yaml():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    assert isinstance(data, dict), "Workflow must be a valid YAML mapping"
+
+
+# ── workflow_call trigger & inputs ──
+
+
+def test_has_workflow_call_trigger():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    on_block = _get_on_block(data)
+    assert "workflow_call" in on_block, "Must have workflow_call trigger"
+
+
+def test_workflow_call_has_python_version_input():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    on_block = _get_on_block(data)
+    inputs = on_block["workflow_call"].get("inputs", {})
+    pv = inputs.get("python-version", {})
+    assert pv, "Must define python-version input"
+    assert pv.get("default") == "3.13", "python-version default must be '3.13'"
+
+
+def test_workflow_call_has_run_tests_input():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    on_block = _get_on_block(data)
+    inputs = on_block["workflow_call"].get("inputs", {})
+    rt = inputs.get("run-tests", {})
+    assert rt, "Must define run-tests input"
+    assert rt.get("default") is True, "run-tests default must be true"
+
+
+def test_workflow_call_has_run_lint_input():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    on_block = _get_on_block(data)
+    inputs = on_block["workflow_call"].get("inputs", {})
+    rl = inputs.get("run-lint", {})
+    assert rl, "Must define run-lint input"
+    assert rl.get("default") is True, "run-lint default must be true"
+
+
+# ── jobs ──
+
+
+def test_defines_lint_job():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    jobs = data.get("jobs", {})
+    assert "lint" in jobs, "Must define lint job"
+
+
+def test_defines_test_job():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    jobs = data.get("jobs", {})
+    assert "test" in jobs, "Must define test job"
+
+
+def test_lint_job_runs_ruff_check():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    lint_steps = data["jobs"]["lint"].get("steps", [])
+    run_cmds = [s["run"] for s in lint_steps if "run" in s]
+    assert any("ruff check" in cmd for cmd in run_cmds), "lint job must run ruff check"
+
+
+def test_lint_job_runs_ruff_format():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    lint_steps = data["jobs"]["lint"].get("steps", [])
+    run_cmds = [s["run"] for s in lint_steps if "run" in s]
+    assert any("ruff format" in cmd for cmd in run_cmds), "lint job must run ruff format"
+
+
+def test_test_job_runs_pytest_with_markers():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    test_steps = data["jobs"]["test"].get("steps", [])
+    run_cmds = [s["run"] for s in test_steps if "run" in s]
+    assert any("pytest" in cmd and "small or medium" in cmd for cmd in run_cmds), (
+        'test job must run pytest with -m "small or medium"'
+    )
+
+
+# ── actions versions ──
+
+
+def test_uses_actions_checkout_v6():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    checkout_found = False
+    for job in data.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            uses = step.get("uses", "")
+            if "actions/checkout" in uses:
+                assert uses == "actions/checkout@v6"
+                checkout_found = True
+    assert checkout_found, "Must use actions/checkout@v6"
+
+
+def test_uses_setup_uv_v7():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    uv_found = False
+    for job in data.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            uses = step.get("uses", "")
+            if "setup-uv" in uses:
+                assert uses == "astral-sh/setup-uv@v7"
+                uv_found = True
+    assert uv_found, "Must use astral-sh/setup-uv@v7"
+
+
+def test_setup_uv_enables_cache():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    for job in data.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            if "setup-uv" in step.get("uses", ""):
+                with_block = step.get("with", {})
+                assert with_block.get("enable-cache") is True, (
+                    "setup-uv must have enable-cache: true"
+                )
+
+
+# ── permissions ──
+
+
+def test_has_contents_read_permission():
+    data = _load_workflow(REUSABLE_CI_PATH)
+    permissions = data.get("permissions", {})
+    assert permissions.get("contents") == "read", "Must declare contents: read"
+
+
+# ── security: no expression interpolation in run blocks ──
+
+
+def test_no_expression_interpolation_in_run_blocks():
+    """Ensure no ${{ }} expressions appear in run: blocks."""
+    data = _load_workflow(REUSABLE_CI_PATH)
+    for job in data.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            if "run" in step:
+                assert "${{" not in step["run"], (
+                    f"run: blocks must not contain ${{{{ }}}} expressions; "
+                    f"use env: instead. Found in: {step['run']}"
+                )
+
+
+# ── lint.yml calls reusable workflow ──
+
+
+def test_lint_yml_calls_reusable_workflow():
+    """lint.yml should delegate to the reusable workflow."""
+    data = _load_workflow(LINT_PATH)
+    jobs = data.get("jobs", {})
+    uses_reusable = False
+    for job in jobs.values():
+        uses = job.get("uses", "")
+        if "reusable-python-ci.yml" in uses:
+            uses_reusable = True
+    assert uses_reusable, "lint.yml must call reusable-python-ci.yml"

--- a/tests/test_shared_workflows.py
+++ b/tests/test_shared_workflows.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 import yaml
 
-REUSABLE_CI_PATH = (
-    Path(__file__).parent.parent / ".github" / "workflows" / "reusable-python-ci.yml"
-)
+REUSABLE_CI_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "reusable-python-ci.yml"
 LINT_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "lint.yml"
 
 
@@ -45,27 +43,27 @@ def test_workflow_call_has_python_version_input():
     data = _load_workflow(REUSABLE_CI_PATH)
     on_block = _get_on_block(data)
     inputs = on_block["workflow_call"].get("inputs", {})
-    pv = inputs.get("python-version", {})
-    assert pv, "Must define python-version input"
-    assert pv.get("default") == "3.13", "python-version default must be '3.13'"
+    pv = inputs.get("python_version", {})
+    assert pv, "Must define python_version input"
+    assert pv.get("default") == "3.13", "python_version default must be '3.13'"
 
 
 def test_workflow_call_has_run_tests_input():
     data = _load_workflow(REUSABLE_CI_PATH)
     on_block = _get_on_block(data)
     inputs = on_block["workflow_call"].get("inputs", {})
-    rt = inputs.get("run-tests", {})
-    assert rt, "Must define run-tests input"
-    assert rt.get("default") is True, "run-tests default must be true"
+    rt = inputs.get("run_tests", {})
+    assert rt, "Must define run_tests input"
+    assert rt.get("default") is True, "run_tests default must be true"
 
 
 def test_workflow_call_has_run_lint_input():
     data = _load_workflow(REUSABLE_CI_PATH)
     on_block = _get_on_block(data)
     inputs = on_block["workflow_call"].get("inputs", {})
-    rl = inputs.get("run-lint", {})
-    assert rl, "Must define run-lint input"
-    assert rl.get("default") is True, "run-lint default must be true"
+    rl = inputs.get("run_lint", {})
+    assert rl, "Must define run_lint input"
+    assert rl.get("default") is True, "run_lint default must be true"
 
 
 # ── jobs ──
@@ -139,9 +137,7 @@ def test_setup_uv_enables_cache():
         for step in job.get("steps", []):
             if "setup-uv" in step.get("uses", ""):
                 with_block = step.get("with", {})
-                assert with_block.get("enable-cache") is True, (
-                    "setup-uv must have enable-cache: true"
-                )
+                assert with_block.get("enable-cache") is True, "setup-uv must have enable-cache: true"
 
 
 # ── permissions ──
@@ -163,8 +159,7 @@ def test_no_expression_interpolation_in_run_blocks():
         for step in job.get("steps", []):
             if "run" in step:
                 assert "${{" not in step["run"], (
-                    f"run: blocks must not contain ${{{{ }}}} expressions; "
-                    f"use env: instead. Found in: {step['run']}"
+                    f"run: blocks must not contain ${{{{ }}}} expressions; use env: instead. Found in: {step['run']}"
                 )
 
 


### PR DESCRIPTION
## Summary
- Add reusable-python-ci.yml — a workflow_call reusable workflow with configurable inputs (python-version, run-tests, run-lint), lint (ruff check + format) and test (pytest with marker filter) jobs
- Refactor lint.yml to delegate lint and test to the reusable workflow while keeping typecheck and backward-compatible triggers
- Add 17 tests in test_shared_workflows.py covering structure, inputs, jobs, action versions, permissions, and security (no expression interpolation in run blocks)

Closes #79