### PR TITLE
chore: 🔧 add code-structure skills and tighten commit limits

### DIFF
--- a/.claude/skills/code-structure/SKILL.md
+++ b/.claude/skills/code-structure/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: code-structure
+description: Code structure rules (file size, function size, single responsibility, layer separation). Reference this when writing or reviewing implementation code.
+user-invocable: false
+---
+
+# Code Structure Rules
+
+## File Size
+
+- Source files: **300 lines max** (excludes tests and auto-generated files)
+- When exceeding: extract functionality into a separate module
+- Exceptions allowed only with justification in a comment
+
+## Function / Method Size
+
+- **50 lines max** per function or method
+- When exceeding: split into helper functions or private methods
+- Test helpers and fixtures are exempt
+
+## Single Responsibility
+
+- Each module focuses on **one concern**
+- Litmus test: can you describe what this file does in one sentence?
+- A dataclass + its associated logic may live in the same file
+- Examples from this codebase:
+  - `rate_limiter.py` — GitHub API rate limit parsing only
+  - `sanitizer.py` — secret detection only
+
+## Layer Separation
+
+| Layer | Location | Responsibility | May depend on |
+|-------|----------|---------------|---------------|
+| CLI | `cli.py` | User I/O, Typer command definitions only | Domain |
+| Domain | `src/myxo/*.py` | Core business logic | (interfaces only) |
+| Infra | `infra/` | Pulumi resource definitions, cloud config | Domain |
+| Tests | `tests/` | 1:1 mapping with source (`test_{module}.py`) | Domain, CLI |
+
+**Dependency direction:** CLI → Domain ← Infra (no reverse dependencies)
+
+- CLI must not contain business logic — delegate to domain modules
+- Domain modules must not import from CLI or infra directly
+
+## When Limits Are Approaching
+
+- Propose file splitting **before** implementation, not after
+- Split by responsibility, not by arbitrary line count
+- Prefer extracting a cohesive module over mechanical splitting

--- a/.claude/skills/commit-rules/SKILL.md
+++ b/.claude/skills/commit-rules/SKILL.md
@@ -92,9 +92,9 @@ Refs #12
 ### Code Changes
 
 - Max **10 files** per commit
-- Max **300 lines** added+deleted (excluding tests and auto-generated files)
+- Max **200 lines** added+deleted (excluding tests and auto-generated files)
 - **1 commit = 1 concern** — never mix feat and fix in the same commit
-- Auto-generated files (uv.lock, package-lock.json) do not count toward limits
+- Auto-generated files (uv.lock, package-lock.json, Cargo.lock) do not count toward limits
 - If limits are exceeded, split the commit. If splitting is impractical, explain why in the body.
 
 ### Test Code

--- a/.claude/skills/python-code-structure/SKILL.md
+++ b/.claude/skills/python-code-structure/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: code-structure
-description: Code structure rules (file size, function size, single responsibility, layer separation). Reference this when writing or reviewing implementation code.
+name: python-code-structure
+description: Python code structure rules for src/myxo/ (file size, function size, single responsibility, layer separation). Reference this when writing or reviewing Python implementation code.
 user-invocable: false
 ---
 
-# Code Structure Rules
+# Python Code Structure Rules
 
 ## File Size
 
@@ -40,6 +40,28 @@ user-invocable: false
 
 - CLI must not contain business logic — delegate to domain modules
 - Domain modules must not import from CLI or infra directly
+
+## Gotchas
+
+- `__init__.py` is exempt from single responsibility — it serves as the package's public API surface
+- Test files often exceed 300 lines because of fixtures and parametrized cases — this is expected
+- `cli.py` tends to grow as commands are added; when it exceeds 300 lines, split into `cli/` package with one file per command group
+- Pulumi infra files (`infra/`) follow Pulumi conventions (resource definitions in sequence), not general domain patterns — layer separation rules still apply but internal structure may differ
+- Auto-generated files (`uv.lock`, `package-lock.json`) and config files (`pyproject.toml`) are exempt from all limits
+
+## Validation
+
+After writing or modifying source files, verify limits:
+
+```bash
+# Check file sizes (source files only, excludes tests and auto-generated)
+find src/ -name '*.py' ! -name '__init__.py' -exec awk 'END{if(NR>300) print FILENAME": "NR" lines"}' {} \;
+
+# Check function sizes
+ruff check --select E302 src/
+```
+
+If any file exceeds 300 lines, propose a split before committing.
 
 ## When Limits Are Approaching
 

--- a/.claude/skills/python-code-structure/SKILL.md
+++ b/.claude/skills/python-code-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-code-structure
-description: Python code structure rules for src/myxo/ (file size, function size, single responsibility, layer separation). Reference this when writing or reviewing Python implementation code.
+description: Python code structure rules (file size, function size, single responsibility, layer separation). Reference this when writing or reviewing Python code including Pulumi infra.
 user-invocable: false
 ---
 

--- a/.claude/skills/python-code-structure/SKILL.md
+++ b/.claude/skills/python-code-structure/SKILL.md
@@ -24,15 +24,15 @@ user-invocable: false
 - Litmus test: can you describe what this file does in one sentence?
 - A dataclass + its associated logic may live in the same file
 - Examples from this codebase:
-  - `rate_limiter.py` — GitHub API rate limit parsing only
-  - `sanitizer.py` — secret detection only
+  - `src/myxo/rate_limiter.py` — GitHub API rate limiting: parse headers and log warnings
+  - `src/myxo/sanitizer.py` — secret handling: detect and redact sensitive values
 
 ## Layer Separation
 
 | Layer | Location | Responsibility | May depend on |
 |-------|----------|---------------|---------------|
-| CLI | `cli.py` | User I/O, Typer command definitions only | Domain |
-| Domain | `src/myxo/*.py` | Core business logic | (interfaces only) |
+| CLI | `src/myxo/cli.py` | User I/O, Typer command definitions only | Domain |
+| Domain | `src/myxo/*.py` (excluding `cli.py`) | Core business logic | (interfaces only) |
 | Infra | `infra/` | Pulumi resource definitions, cloud config | Domain |
 | Tests | `tests/` | 1:1 mapping with source (`test_{module}.py`) | Domain, CLI |
 

--- a/.claude/skills/rust-code-structure/SKILL.md
+++ b/.claude/skills/rust-code-structure/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: rust-code-structure
+description: Rust code structure rules for crates/ (file size, function size, module organization, crate separation). Reference this when writing or reviewing Rust implementation code.
+user-invocable: false
+---
+
+# Rust Code Structure Rules
+
+## File Size
+
+- Source files: **500 lines max** (excludes tests and auto-generated files)
+- `impl` blocks, `match` arms, and type definitions contribute to higher line counts — this is expected
+- When exceeding: extract into a submodule or separate file
+- Build files incrementally — a 500-line file should grow over multiple commits, not appear in one
+
+## Function / Method Size
+
+- **50 lines max** per function or method
+- `?` operator keeps error handling concise — long functions usually indicate mixed concerns
+- When exceeding: extract helper functions as `fn` or closures
+
+## Single Responsibility
+
+- Each module focuses on **one concern**
+- Litmus test: can you describe what this module does in one sentence?
+- A struct + its `impl` block naturally live in the same file
+- When a module grows submodules, use directory form: `verifier/mod.rs` + `verifier/labels.rs`
+
+## Crate Separation
+
+| Crate | Location | Responsibility | May depend on |
+|-------|----------|---------------|---------------|
+| CLI | `crates/myxo-cli/` | `clap` parsing, user I/O, output formatting only | Core |
+| Core | `crates/myxo-core/` | Domain logic, traits, types | (external crates only) |
+
+**Dependency direction:** CLI → Core (no reverse dependency)
+
+- CLI is a thin entry point — delegate all logic to Core
+- Core must not depend on CLI or any presentation concern
+- Use `pub(crate)` by default; only `pub` what the crate's public API needs
+- Re-export key types from `lib.rs` for a clean public surface
+
+## Module Organization
+
+As `myxo-core` grows, organize by domain concern:
+
+```
+crates/myxo-core/src/
+├── lib.rs           # pub mod declarations, re-exports
+├── error.rs         # thiserror error types
+├── config.rs        # serde_yaml config parsing
+├── verifier.rs      # or verifier/mod.rs + submodules
+├── syncer.rs
+└── protocol.rs
+```
+
+- Prefer flat files (`verifier.rs`) until complexity demands submodules
+- Split into `verifier/mod.rs` + submodules when a file exceeds 500 lines or has distinct sub-concerns
+
+## Testing
+
+- **Unit tests**: `#[cfg(test)] mod tests` inside the source file
+- **Integration tests**: `crates/myxo-cli/tests/` (one file per feature area)
+- Test files are exempt from the 500-line limit
+- Test module naming: `tests/cli_test.rs`, `tests/verifier_test.rs`
+
+## Gotchas
+
+- `Cargo.lock` is committed (binary crate) — but exempt from diff limits in commit-rules
+- `mod.rs` is only needed for directory-based modules; prefer `verifier.rs` over `verifier/mod.rs` for simple modules
+- Clippy runs with `-D warnings` in CI — fix all warnings before committing
+- Edition 2024 uses the new `use` import style; `extern crate` is unnecessary
+- `#[derive]` macros (Clone, Debug, Serialize, etc.) add visual bulk but are zero-cost — don't count them as "complexity"
+
+## Validation
+
+After writing or modifying source files:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all
+```
+
+If any source file exceeds 500 lines, propose a split before committing.


### PR DESCRIPTION
## Summary
- Add `python-code-structure` skill (300 lines/file, 50 lines/function, layer separation)
- Add `rust-code-structure` skill (500 lines/file, 50 lines/function, crate separation)
- Tighten commit diff limit from 300 to 200 lines for incremental development
- Add `Cargo.lock` to auto-generated file exclusion list in commit-rules

Refs #212