### PR TITLE
feat: ✨ configure per-purpose API keys in GitHub Secrets via Pulumi

### DIFF
--- a/infra/secrets.py
+++ b/infra/secrets.py
@@ -20,6 +20,11 @@ pulumi_access_token = secrets_config.require_secret("PULUMI_ACCESS_TOKEN")
 aws_access_key_id = secrets_config.require_secret("AWS_ACCESS_KEY_ID")
 aws_secret_access_key = secrets_config.require_secret("AWS_SECRET_ACCESS_KEY")
 
+# Purpose-specific API keys (#28)
+anthropic_api_key_myxo = secrets_config.require_secret("ANTHROPIC_API_KEY_MYXO")
+anthropic_api_key_scheduled = secrets_config.require_secret("ANTHROPIC_API_KEY_SCHEDULED")
+github_app_private_key = secrets_config.require_secret("GITHUB_APP_PRIVATE_KEY")
+
 # ---------------------------------------------------------------------------
 # GitHub Environments
 # ---------------------------------------------------------------------------
@@ -48,6 +53,9 @@ SECRET_DEFS: dict[str, pulumi.Output[str]] = {
     "PULUMI_ACCESS_TOKEN": pulumi_access_token,
     "AWS_ACCESS_KEY_ID": aws_access_key_id,
     "AWS_SECRET_ACCESS_KEY": aws_secret_access_key,
+    "ANTHROPIC_API_KEY_MYXO": anthropic_api_key_myxo,
+    "ANTHROPIC_API_KEY_SCHEDULED": anthropic_api_key_scheduled,
+    "GITHUB_APP_PRIVATE_KEY": github_app_private_key,
 }
 
 for secret_name, secret_value in SECRET_DEFS.items():

--- a/infra/secrets.py
+++ b/infra/secrets.py
@@ -20,7 +20,7 @@ pulumi_access_token = secrets_config.require_secret("PULUMI_ACCESS_TOKEN")
 aws_access_key_id = secrets_config.require_secret("AWS_ACCESS_KEY_ID")
 aws_secret_access_key = secrets_config.require_secret("AWS_SECRET_ACCESS_KEY")
 
-# Purpose-specific API keys (#28)
+# Purpose-specific secrets (#28)
 anthropic_api_key_myxo = secrets_config.require_secret("ANTHROPIC_API_KEY_MYXO")
 anthropic_api_key_scheduled = secrets_config.require_secret("ANTHROPIC_API_KEY_SCHEDULED")
 github_app_private_key = secrets_config.require_secret("GITHUB_APP_PRIVATE_KEY")

--- a/tests/test_secrets_infra.py
+++ b/tests/test_secrets_infra.py
@@ -120,9 +120,7 @@ def test_all_new_secrets_use_require_secret():
     ]
     for name in new_secret_names:
         pattern = rf'require_secret\(\s*"{name}"\s*\)'
-        assert re.search(pattern, src), (
-            f"{name} must be loaded via require_secret(), not plaintext"
-        )
+        assert re.search(pattern, src), f"{name} must be loaded via require_secret(), not plaintext"
 
 
 def test_purpose_based_naming_pattern():
@@ -133,8 +131,7 @@ def test_purpose_based_naming_pattern():
     purpose_keywords = {"MYXO", "SCHEDULED", "APP"}
     found = {kw for kw in purpose_keywords if any(kw in k for k in secret_def_keys)}
     assert found == purpose_keywords, (
-        f"SECRET_DEFS must contain purpose-based keys with {purpose_keywords}, "
-        f"but only found {found}"
+        f"SECRET_DEFS must contain purpose-based keys with {purpose_keywords}, but only found {found}"
     )
 
 

--- a/tests/test_secrets_infra.py
+++ b/tests/test_secrets_infra.py
@@ -88,6 +88,57 @@ def test_defines_aws_secret_access_key_secret():
 
 
 # ---------------------------------------------------------------------------
+# Purpose-specific API key secrets (#28)
+# ---------------------------------------------------------------------------
+
+
+def test_defines_anthropic_api_key_myxo_secret():
+    """secrets.py must define ANTHROPIC_API_KEY_MYXO for worker agent execution."""
+    src = _secrets_source()
+    assert "ANTHROPIC_API_KEY_MYXO" in src
+
+
+def test_defines_anthropic_api_key_scheduled_secret():
+    """secrets.py must define ANTHROPIC_API_KEY_SCHEDULED for cron tasks."""
+    src = _secrets_source()
+    assert "ANTHROPIC_API_KEY_SCHEDULED" in src
+
+
+def test_defines_github_app_private_key_secret():
+    """secrets.py must define GITHUB_APP_PRIVATE_KEY for GitHub App token generation."""
+    src = _secrets_source()
+    assert "GITHUB_APP_PRIVATE_KEY" in src
+
+
+def test_all_new_secrets_use_require_secret():
+    """All purpose-specific secrets must use require_secret (no plaintext)."""
+    src = _secrets_source()
+    new_secret_names = [
+        "ANTHROPIC_API_KEY_MYXO",
+        "ANTHROPIC_API_KEY_SCHEDULED",
+        "GITHUB_APP_PRIVATE_KEY",
+    ]
+    for name in new_secret_names:
+        pattern = rf'require_secret\(\s*"{name}"\s*\)'
+        assert re.search(pattern, src), (
+            f"{name} must be loaded via require_secret(), not plaintext"
+        )
+
+
+def test_purpose_based_naming_pattern():
+    """SECRET_DEFS must contain keys matching purpose-based naming (MYXO, SCHEDULED, APP)."""
+    src = _secrets_source()
+    # Extract keys from SECRET_DEFS dict
+    secret_def_keys = re.findall(r'"([A-Z_]+)":\s*\w+', src)
+    purpose_keywords = {"MYXO", "SCHEDULED", "APP"}
+    found = {kw for kw in purpose_keywords if any(kw in k for k in secret_def_keys)}
+    assert found == purpose_keywords, (
+        f"SECRET_DEFS must contain purpose-based keys with {purpose_keywords}, "
+        f"but only found {found}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Security: no hardcoded secrets
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add 3 purpose-specific API key secrets to infra/secrets.py: ANTHROPIC_API_KEY_MYXO (worker agent), ANTHROPIC_API_KEY_SCHEDULED (cron tasks), GITHUB_APP_PRIVATE_KEY (GitHub App token generation for #70)
- All new secrets loaded via require_secret() from Pulumi encrypted config — no plaintext values
- Add 5 source-level tests verifying secret definitions, require_secret usage, and purpose-based naming patterns

Closes #28