### PR TITLE
feat: ✨ add EFS Nix store cache for Fargate tasks

### DIFF
--- a/infra/ecs.py
+++ b/infra/ecs.py
@@ -84,6 +84,28 @@ task_role = iam.Role(
     ),
 )
 
+# EFS client permissions for task role
+iam.RolePolicy(
+    "myxo-task-efs-policy",
+    role=task_role.name,
+    policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "elasticfilesystem:ClientMount",
+                        "elasticfilesystem:ClientWrite",
+                        "elasticfilesystem:DescribeMountTargets",
+                    ],
+                    "Resource": "*",
+                }
+            ],
+        }
+    ),
+)
+
 # --- Fargate Spot Capacity Providers ----------------------------------------
 ecs.ClusterCapacityProviders(
     "myxo-cluster-capacity-providers",

--- a/infra/ecs.py
+++ b/infra/ecs.py
@@ -4,6 +4,7 @@ Defines minimal ECS infrastructure:
 - ECS Cluster, ECR Repository, CloudWatch Log Group
 - IAM roles (task execution + task)
 - Fargate Task Definition (0.25 vCPU / 512 MB)
+- EFS file system for Nix store cache
 """
 
 import json
@@ -102,6 +103,32 @@ ecs.ClusterCapacityProviders(
     ],
 )
 
+# --- EFS: Nix store cache ----------------------------------------------------
+nix_cache_fs = aws.efs.FileSystem(
+    "myxo-nix-cache",
+    encrypted=True,
+    performance_mode="generalPurpose",
+    tags={"Name": "myxo-nix-cache"},
+)
+
+nix_cache_ap = aws.efs.AccessPoint(
+    "myxo-nix-cache-ap",
+    file_system_id=nix_cache_fs.id,
+    posix_user=aws.efs.AccessPointPosixUserArgs(uid=1000, gid=1000),
+    root_directory=aws.efs.AccessPointRootDirectoryArgs(
+        path="/nix-store",
+        creation_info=aws.efs.AccessPointRootDirectoryCreationInfoArgs(
+            owner_uid=1000,
+            owner_gid=1000,
+            permissions="755",
+        ),
+    ),
+    tags={"Name": "myxo-nix-cache-ap"},
+)
+
+# TODO(#137): Add EFS Mount Target once VPC/subnet resources are available.
+# aws.efs.MountTarget("myxo-nix-cache-mt", ...)
+
 # --- ECS Task Definition -----------------------------------------------------
 task_definition = ecs.TaskDefinition(
     "myxo-task",
@@ -112,6 +139,19 @@ task_definition = ecs.TaskDefinition(
     requires_compatibilities=["FARGATE"],
     execution_role_arn=task_execution_role.arn,
     task_role_arn=task_role.arn,
+    volumes=[
+        ecs.TaskDefinitionVolumeArgs(
+            name="nix-cache",
+            efs_volume_configuration=ecs.TaskDefinitionVolumeEfsVolumeConfigurationArgs(
+                file_system_id=nix_cache_fs.id,
+                transit_encryption="ENABLED",
+                authorization_config=ecs.TaskDefinitionVolumeEfsVolumeConfigurationAuthorizationConfigArgs(
+                    access_point_id=nix_cache_ap.id,
+                    iam="ENABLED",
+                ),
+            ),
+        ),
+    ],
     container_definitions=pulumi.Output.all(repo.repository_url, log_group.name).apply(
         lambda args: json.dumps(
             [
@@ -121,6 +161,13 @@ task_definition = ecs.TaskDefinition(
                     "cpu": 256,
                     "memory": 512,
                     "essential": True,
+                    "mountPoints": [
+                        {
+                            "sourceVolume": "nix-cache",
+                            "containerPath": "/nix",
+                            "readOnly": False,
+                        }
+                    ],
                     "logConfiguration": {
                         "logDriver": "awslogs",
                         "options": {
@@ -139,3 +186,4 @@ task_definition = ecs.TaskDefinition(
 pulumi.export("cluster_name", cluster.name)
 pulumi.export("ecr_url", repo.repository_url)
 pulumi.export("task_definition_arn", task_definition.arn)
+pulumi.export("efs_file_system_id", nix_cache_fs.id)

--- a/tests/test_ecs_infra.py
+++ b/tests/test_ecs_infra.py
@@ -106,3 +106,39 @@ def test_default_capacity_provider_strategy():
     """ecs.py must define a default capacity provider strategy."""
     src = _ecs_source()
     assert "default_capacity_provider_strategies" in src
+
+
+# ---------------------------------------------------------------------------
+# EFS Nix cache (#137)
+# ---------------------------------------------------------------------------
+
+
+def test_defines_efs_file_system():
+    """ecs.py must define an EFS FileSystem resource."""
+    src = _ecs_source()
+    assert "aws.efs.FileSystem(" in src, "ecs.py must define aws.efs.FileSystem"
+
+
+def test_defines_efs_access_point():
+    """ecs.py must define an EFS AccessPoint resource."""
+    src = _ecs_source()
+    assert "aws.efs.AccessPoint(" in src, "ecs.py must define aws.efs.AccessPoint"
+
+
+def test_task_definition_has_volume():
+    """Task definition must include a volume configuration for EFS."""
+    src = _ecs_source()
+    assert "nix-cache" in src, "Task definition must reference nix-cache volume"
+    assert "efs_volume_configuration" in src or "EfsVolumeConfiguration" in src
+
+
+def test_efs_resources_use_myxo_naming():
+    """EFS resources must use 'myxo' in their names."""
+    src = _ecs_source()
+    assert "myxo-nix-cache" in src, "EFS file system must be named myxo-nix-cache"
+
+
+def test_exports_efs_file_system_id():
+    """ecs.py must export the EFS file system ID."""
+    src = _ecs_source()
+    assert "efs_file_system_id" in src, "Must export efs_file_system_id"


### PR DESCRIPTION
## Summary
- Add EFS FileSystem (myxo-nix-cache) with encryption and generalPurpose performance mode to cache the Nix store across Fargate task runs
- Add EFS AccessPoint with /nix-store root path and POSIX user 1000:1000
- Update ECS task definition with EFS volume (nix-cache) mounted at /nix in the container, with transit encryption and IAM auth enabled
- Export efs_file_system_id for cross-stack references
- Add TODO for EFS MountTarget (requires VPC/subnet resources)

Refs #137 (partial — remaining: cost monitoring, image optimization)