### PR TITLE
feat: ✨ add auto-cleanup infrastructure for PR close events

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,8 +1,9 @@
 """Myxo Lab infrastructure definition."""
 
-import pulumi
+import pulumi  # noqa: I001
 import pulumi_github as github
 
+import cleanup  # noqa: F401 — PR cleanup Lambda resources
 import ecs  # noqa: F401 — ECS Fargate resources (Pulumi runs from infra/ directory)
 import secrets  # noqa: F401 — GitHub Secrets & Environments
 import stale_cleanup  # noqa: F401 — Stale resource cleanup Lambda + EventBridge

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,10 +1,9 @@
 """Myxo Lab infrastructure definition."""
 
-import pulumi  # noqa: I001
-import pulumi_github as github
-
 import cleanup  # noqa: F401 — PR cleanup Lambda resources
-import ecs  # noqa: F401 — ECS Fargate resources (Pulumi runs from infra/ directory)
+import ecs  # noqa: F401 — ECS Fargate resources
+import pulumi
+import pulumi_github as github
 import secrets  # noqa: F401 — GitHub Secrets & Environments
 import stale_cleanup  # noqa: F401 — Stale resource cleanup Lambda + EventBridge
 

--- a/infra/cleanup.py
+++ b/infra/cleanup.py
@@ -1,0 +1,119 @@
+"""Cleanup Lambda resources for PR close event handling.
+
+Defines infrastructure to automatically clean up preview resources
+when a pull request is closed:
+- Lambda Function — handles PR close webhook events
+- IAM Role — execution permissions (CloudWatch Logs + ECS stop)
+- CloudWatch Log Group — Lambda log retention
+- EventBridge Rule — triggers Lambda on PR close events
+"""
+
+import json
+
+import pulumi
+import pulumi_aws as aws
+
+iam = aws.iam
+cloudwatch = aws.cloudwatch
+
+# --- CloudWatch Log Group for Lambda ----------------------------------------
+cleanup_log_group = cloudwatch.LogGroup(
+    "myxo-pr-cleanup-logs",
+    name="/aws/lambda/myxo-pr-cleanup",
+    retention_in_days=14,
+)
+
+# --- IAM Role for Lambda execution ------------------------------------------
+cleanup_role = iam.Role(
+    "myxo-pr-cleanup-role",
+    name="myxo-pr-cleanup-role",
+    assume_role_policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    ),
+)
+
+# CloudWatch Logs permissions
+iam.RolePolicyAttachment(
+    "myxo-pr-cleanup-logs-policy",
+    role=cleanup_role.name,
+    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+)
+
+# ECS task stop permissions
+iam.RolePolicy(
+    "myxo-pr-cleanup-ecs-policy",
+    role=cleanup_role.id,
+    policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "ecs:StopTask",
+                        "ecs:ListTasks",
+                        "ecs:DescribeTasks",
+                    ],
+                    "Resource": "*",
+                }
+            ],
+        }
+    ),
+)
+
+# --- Lambda Function --------------------------------------------------------
+cleanup_lambda = aws.lambda_.Function(
+    "myxo-pr-cleanup",
+    function_name="myxo-pr-cleanup",
+    runtime="python3.13",
+    handler="handler.handle",
+    timeout=60,
+    memory_size=128,
+    role=cleanup_role.arn,
+    description="Clean up preview resources when PR is closed",
+    code=pulumi.AssetArchive(
+        {"handler.py": pulumi.FileAsset("../lambda/pr_cleanup/handler.py")}
+    ),
+)
+
+# --- EventBridge Rule -------------------------------------------------------
+pr_close_rule = cloudwatch.EventRule(
+    "myxo-pr-close-rule",
+    name="myxo-pr-close-rule",
+    description="Trigger cleanup Lambda on GitHub PR close events",
+    event_pattern=json.dumps(
+        {
+            "source": ["aws.partner/github.com"],
+            "detail-type": ["pull_request"],
+            "detail": {"action": ["closed"]},
+        }
+    ),
+)
+
+cloudwatch.EventTarget(
+    "myxo-pr-close-target",
+    rule=pr_close_rule.name,
+    arn=cleanup_lambda.arn,
+)
+
+# Allow EventBridge to invoke the Lambda
+aws.lambda_.Permission(
+    "myxo-pr-cleanup-eventbridge-permission",
+    action="lambda:InvokeFunction",
+    function=cleanup_lambda.name,
+    principal="events.amazonaws.com",
+    source_arn=pr_close_rule.arn,
+)
+
+# --- Exports ----------------------------------------------------------------
+pulumi.export("cleanup_lambda_arn", cleanup_lambda.arn)
+pulumi.export("cleanup_rule_arn", pr_close_rule.arn)

--- a/infra/cleanup.py
+++ b/infra/cleanup.py
@@ -51,7 +51,7 @@ iam.RolePolicyAttachment(
 # ECS task stop permissions
 iam.RolePolicy(
     "myxo-pr-cleanup-ecs-policy",
-    role=cleanup_role.id,
+    role=cleanup_role.name,
     policy=json.dumps(
         {
             "Version": "2012-10-17",
@@ -63,7 +63,7 @@ iam.RolePolicy(
                         "ecs:ListTasks",
                         "ecs:DescribeTasks",
                     ],
-                    "Resource": "*",
+                    "Resource": "arn:aws:ecs:*:*:task/myxo-cluster/*",
                 }
             ],
         }
@@ -80,9 +80,7 @@ cleanup_lambda = aws.lambda_.Function(
     memory_size=128,
     role=cleanup_role.arn,
     description="Clean up preview resources when PR is closed",
-    code=pulumi.AssetArchive(
-        {"handler.py": pulumi.FileAsset("../lambda/pr_cleanup/handler.py")}
-    ),
+    code=pulumi.AssetArchive({"handler.py": pulumi.FileAsset("../lambda/pr_cleanup/handler.py")}),
 )
 
 # --- EventBridge Rule -------------------------------------------------------

--- a/lambda/pr_cleanup/handler.py
+++ b/lambda/pr_cleanup/handler.py
@@ -1,0 +1,45 @@
+"""PR cleanup Lambda handler.
+
+Handles PR close events from EventBridge and cleans up associated
+preview resources (ECS tasks, preview environments).
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def handle(event, context):
+    """Handle a PR close event.
+
+    Args:
+        event: EventBridge event payload containing PR details.
+        context: Lambda execution context (unused).
+
+    Returns:
+        dict with statusCode and JSON body.
+    """
+    detail = event.get("detail", {})
+    action = detail.get("action", "unknown")
+    pr = detail.get("pull_request", {})
+    pr_number = pr.get("number", 0)
+
+    logger.info("PR #%s action=%s — cleanup triggered", pr_number, action)
+
+    # TODO: implement actual cleanup logic
+    # - Stop ECS tasks tagged with this PR number
+    # - Delete preview environment resources
+    # - Clean up associated DNS/routing entries
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(
+            {
+                "message": "cleanup acknowledged",
+                "pr_number": pr_number,
+                "action": action,
+            }
+        ),
+    }

--- a/tests/test_cleanup_infra.py
+++ b/tests/test_cleanup_infra.py
@@ -1,0 +1,98 @@
+"""Cleanup Lambda infrastructure source-level tests.
+
+Since we cannot run ``pulumi up`` in CI, these tests validate that the
+infrastructure source code defines the expected AWS resources for PR
+cleanup using "myxo" naming throughout.
+"""
+
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+
+
+# ---------------------------------------------------------------------------
+# Module existence
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_module_exists():
+    """infra/cleanup.py must exist."""
+    assert (INFRA_DIR / "cleanup.py").is_file(), "infra/cleanup.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Resource definitions in cleanup.py
+# ---------------------------------------------------------------------------
+
+
+def _cleanup_source() -> str:
+    return (INFRA_DIR / "cleanup.py").read_text()
+
+
+def test_defines_lambda_function():
+    """cleanup.py must define a Lambda Function resource."""
+    src = _cleanup_source()
+    assert "aws.lambda_.Function(" in src or "lambda_.Function(" in src, (
+        "cleanup.py must define a Lambda Function"
+    )
+
+
+def test_defines_iam_role():
+    """cleanup.py must define an IAM Role for Lambda execution."""
+    src = _cleanup_source()
+    assert "iam.Role(" in src, "cleanup.py must define iam.Role"
+
+
+def test_defines_cloudwatch_log_group():
+    """cleanup.py must define a CloudWatch Log Group for Lambda logs."""
+    src = _cleanup_source()
+    assert "cloudwatch.LogGroup(" in src, "cleanup.py must define cloudwatch.LogGroup"
+
+
+def test_defines_eventbridge_rule():
+    """cleanup.py must define an EventBridge Rule for PR close events."""
+    src = _cleanup_source()
+    assert "cloudwatch.EventRule(" in src or "EventRule(" in src, (
+        "cleanup.py must define an EventBridge Rule"
+    )
+
+
+def test_no_pseudopod_references():
+    """All resource names must use 'myxo', not 'pseudopod'."""
+    src = _cleanup_source()
+    assert "pseudopod" not in src.lower()
+
+
+def test_myxo_naming():
+    """Key resources must include 'myxo' in their names."""
+    src = _cleanup_source()
+    assert "myxo-pr-cleanup" in src
+
+
+def test_lambda_runtime_python313():
+    """Lambda must use python3.13 runtime."""
+    src = _cleanup_source()
+    assert "python3.13" in src
+
+
+def test_lambda_timeout():
+    """Lambda must have a timeout of 60 seconds."""
+    src = _cleanup_source()
+    assert "timeout=60" in src
+
+
+def test_lambda_handler():
+    """Lambda handler must be set to handler.handle."""
+    src = _cleanup_source()
+    assert "handler.handle" in src
+
+
+# ---------------------------------------------------------------------------
+# Integration with __main__.py
+# ---------------------------------------------------------------------------
+
+
+def test_main_imports_cleanup_module():
+    """__main__.py must import or reference the cleanup module."""
+    main_src = (INFRA_DIR / "__main__.py").read_text()
+    assert "cleanup" in main_src, "__main__.py must import cleanup module"

--- a/tests/test_cleanup_infra.py
+++ b/tests/test_cleanup_infra.py
@@ -32,9 +32,7 @@ def _cleanup_source() -> str:
 def test_defines_lambda_function():
     """cleanup.py must define a Lambda Function resource."""
     src = _cleanup_source()
-    assert "aws.lambda_.Function(" in src or "lambda_.Function(" in src, (
-        "cleanup.py must define a Lambda Function"
-    )
+    assert "aws.lambda_.Function(" in src or "lambda_.Function(" in src, "cleanup.py must define a Lambda Function"
 
 
 def test_defines_iam_role():
@@ -52,9 +50,7 @@ def test_defines_cloudwatch_log_group():
 def test_defines_eventbridge_rule():
     """cleanup.py must define an EventBridge Rule for PR close events."""
     src = _cleanup_source()
-    assert "cloudwatch.EventRule(" in src or "EventRule(" in src, (
-        "cleanup.py must define an EventBridge Rule"
-    )
+    assert "cloudwatch.EventRule(" in src or "EventRule(" in src, "cleanup.py must define an EventBridge Rule"
 
 
 def test_no_pseudopod_references():

--- a/tests/test_pr_cleanup_handler.py
+++ b/tests/test_pr_cleanup_handler.py
@@ -27,10 +27,16 @@ def test_handler_module_exists():
 
 def _load_handler():
     """Import the handler module dynamically."""
-    handler_dir = Path(__file__).resolve().parent.parent / "lambda" / "pr_cleanup"
-    if str(handler_dir) not in sys.path:
-        sys.path.insert(0, str(handler_dir))
-    return importlib.import_module("handler")
+    handler_dir = str(Path(__file__).resolve().parent.parent / "lambda" / "pr_cleanup")
+    original_path = sys.path.copy()
+    try:
+        if handler_dir not in sys.path:
+            sys.path.insert(0, handler_dir)
+        if "handler" in sys.modules:
+            return importlib.reload(sys.modules["handler"])
+        return importlib.import_module("handler")
+    finally:
+        sys.path[:] = original_path
 
 
 def test_handler_has_handle_function():

--- a/tests/test_pr_cleanup_handler.py
+++ b/tests/test_pr_cleanup_handler.py
@@ -1,0 +1,81 @@
+"""PR cleanup Lambda handler tests.
+
+Validates that the handler module exists, has the expected entry point,
+and returns the correct response format.
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Module existence
+# ---------------------------------------------------------------------------
+
+
+def test_handler_module_exists():
+    """lambda/pr_cleanup/handler.py must exist."""
+    handler_path = Path(__file__).resolve().parent.parent / "lambda" / "pr_cleanup" / "handler.py"
+    assert handler_path.is_file(), "lambda/pr_cleanup/handler.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Handler function
+# ---------------------------------------------------------------------------
+
+
+def _load_handler():
+    """Import the handler module dynamically."""
+    handler_dir = Path(__file__).resolve().parent.parent / "lambda" / "pr_cleanup"
+    if str(handler_dir) not in sys.path:
+        sys.path.insert(0, str(handler_dir))
+    return importlib.import_module("handler")
+
+
+def test_handler_has_handle_function():
+    """handler module must expose a 'handle' function."""
+    mod = _load_handler()
+    assert hasattr(mod, "handle"), "handler module must have a 'handle' function"
+    assert callable(mod.handle)
+
+
+def test_handler_returns_status_code():
+    """handle() must return a dict with 'statusCode'."""
+    mod = _load_handler()
+    event = {
+        "detail": {
+            "action": "closed",
+            "pull_request": {"number": 42},
+        }
+    }
+    result = mod.handle(event, None)
+    assert isinstance(result, dict)
+    assert "statusCode" in result
+
+
+def test_handler_returns_200_on_valid_event():
+    """handle() must return 200 for a valid PR close event."""
+    mod = _load_handler()
+    event = {
+        "detail": {
+            "action": "closed",
+            "pull_request": {"number": 99},
+        }
+    }
+    result = mod.handle(event, None)
+    assert result["statusCode"] == 200
+
+
+def test_handler_body_contains_pr_number():
+    """Response body must reference the PR number."""
+    mod = _load_handler()
+    event = {
+        "detail": {
+            "action": "closed",
+            "pull_request": {"number": 7},
+        }
+    }
+    result = mod.handle(event, None)
+    body = json.loads(result["body"]) if isinstance(result["body"], str) else result["body"]
+    assert body["pr_number"] == 7


### PR DESCRIPTION
## Summary
- Add `infra/cleanup.py` Pulumi module defining Lambda function (`myxo-pr-cleanup`), IAM role, CloudWatch log group, and EventBridge rule for PR close events
- Add `lambda/pr_cleanup/handler.py` stub that parses PR close events, logs PR number/action, and returns structured response
- Import cleanup module in `infra/__main__.py`
- Add source-level tests validating all resource definitions, naming conventions, and handler behavior (16 tests)

Closes #74