### PR TITLE
feat: ✨ add stale resource cleanup with AutoDelete tagging

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -5,6 +5,7 @@ import pulumi_github as github
 
 import ecs  # noqa: F401 — ECS Fargate resources (Pulumi runs from infra/ directory)
 import secrets  # noqa: F401 — GitHub Secrets & Environments
+import stale_cleanup  # noqa: F401 — Stale resource cleanup Lambda + EventBridge
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/infra/stale_cleanup.py
+++ b/infra/stale_cleanup.py
@@ -1,0 +1,130 @@
+"""Stale resource cleanup infrastructure for Myxo Lab.
+
+Defines a Lambda-based cleanup system that scans for AWS resources
+tagged with AutoDelete=true and removes them after their expiry time.
+
+Resources:
+- Lambda Function (myxo-stale-cleanup)
+- IAM Role with permissions for ECS/EC2 describe+delete
+- CloudWatch Log Group for Lambda logs
+- EventBridge Schedule Rule (daily at 03:00 UTC)
+- EventBridge Target connecting rule to Lambda
+"""
+
+import json
+
+import pulumi
+import pulumi_aws as aws
+
+# --- IAM Role for Lambda ---------------------------------------------------
+cleanup_role = aws.iam.Role(
+    "myxo-stale-cleanup-role",
+    name="myxo-stale-cleanup-role",
+    assume_role_policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    ),
+)
+
+# Basic Lambda execution (CloudWatch Logs)
+aws.iam.RolePolicyAttachment(
+    "myxo-stale-cleanup-basic-exec",
+    role=cleanup_role.name,
+    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+)
+
+# Inline policy for ECS + EC2 describe/delete with AutoDelete tag
+aws.iam.RolePolicy(
+    "myxo-stale-cleanup-policy",
+    role=cleanup_role.id,
+    policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "ecs:DescribeTasks",
+                        "ecs:ListTasks",
+                        "ecs:StopTask",
+                        "ec2:DescribeInstances",
+                        "ec2:TerminateInstances",
+                        "tag:GetResources",
+                    ],
+                    "Resource": "*",
+                    "Condition": {
+                        "StringEquals": {
+                            "aws:ResourceTag/AutoDelete": "true",
+                        }
+                    },
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "tag:GetResources",
+                        "ecs:ListTasks",
+                        "ecs:ListClusters",
+                    ],
+                    "Resource": "*",
+                },
+            ],
+        }
+    ),
+)
+
+# --- CloudWatch Log Group --------------------------------------------------
+cleanup_log_group = aws.cloudwatch.LogGroup(
+    "myxo-stale-cleanup-logs",
+    name="/aws/lambda/myxo-stale-cleanup",
+    retention_in_days=14,
+)
+
+# --- Lambda Function -------------------------------------------------------
+cleanup_function = aws.lambda_.Function(
+    "myxo-stale-cleanup",
+    function_name="myxo-stale-cleanup",
+    runtime="python3.13",
+    handler="handler.handle",
+    timeout=300,
+    memory_size=128,
+    role=cleanup_role.arn,
+    code=pulumi.AssetArchive(
+        {".": pulumi.FileArchive("../lambda/stale_cleanup")}
+    ),
+)
+
+# --- EventBridge Schedule Rule ---------------------------------------------
+schedule_rule = aws.cloudwatch.EventRule(
+    "myxo-stale-cleanup-schedule",
+    name="myxo-stale-cleanup-schedule",
+    description="Run stale resource cleanup daily at 03:00 UTC",
+    schedule_expression="cron(0 3 * * ? *)",
+)
+
+# --- EventBridge Target ----------------------------------------------------
+aws.cloudwatch.EventTarget(
+    "myxo-stale-cleanup-target",
+    rule=schedule_rule.name,
+    arn=cleanup_function.arn,
+)
+
+# --- Lambda Permission for EventBridge ------------------------------------
+aws.lambda_.Permission(
+    "myxo-stale-cleanup-invoke",
+    action="lambda:InvokeFunction",
+    function=cleanup_function.name,
+    principal="events.amazonaws.com",
+    source_arn=schedule_rule.arn,
+)
+
+# --- Exports ---------------------------------------------------------------
+pulumi.export("stale_cleanup_function_arn", cleanup_function.arn)
+pulumi.export("stale_cleanup_schedule_rule", schedule_rule.name)

--- a/infra/stale_cleanup.py
+++ b/infra/stale_cleanup.py
@@ -54,11 +54,10 @@ aws.iam.RolePolicy(
                     "Action": [
                         "ecs:DescribeTasks",
                         "ecs:ListTasks",
-                        "ecs:StopTask",
                         "ec2:DescribeInstances",
-                        "ec2:TerminateInstances",
                         "tag:GetResources",
                     ],
+                    "Sid": "ReadOnlyStaleResources",
                     "Resource": "*",
                     "Condition": {
                         "StringEquals": {
@@ -96,9 +95,7 @@ cleanup_function = aws.lambda_.Function(
     timeout=300,
     memory_size=128,
     role=cleanup_role.arn,
-    code=pulumi.AssetArchive(
-        {".": pulumi.FileArchive("../lambda/stale_cleanup")}
-    ),
+    code=pulumi.AssetArchive({".": pulumi.FileArchive("../lambda/stale_cleanup")}),
 )
 
 # --- EventBridge Schedule Rule ---------------------------------------------

--- a/lambda/stale_cleanup/handler.py
+++ b/lambda/stale_cleanup/handler.py
@@ -37,6 +37,8 @@ def _find_stale_resources() -> list[dict]:
 
             try:
                 expiry = datetime.fromisoformat(delete_after)
+                if expiry.tzinfo is None:
+                    expiry = expiry.replace(tzinfo=UTC)
             except ValueError:
                 logger.warning(
                     "Invalid AutoDeleteAfter value '%s' on %s",

--- a/lambda/stale_cleanup/handler.py
+++ b/lambda/stale_cleanup/handler.py
@@ -1,0 +1,89 @@
+"""Stale resource cleanup Lambda handler.
+
+Scans for AWS resources tagged with AutoDelete=true and
+AutoDeleteAfter timestamp. If the timestamp is in the past
+(resource has exceeded its TTL), the resource is logged for
+deletion.
+
+This is a stub — actual deletion logic is a placeholder.
+"""
+
+import json
+import logging
+from datetime import UTC, datetime
+
+import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def _find_stale_resources() -> list[dict]:
+    """Find resources tagged with AutoDelete=true whose TTL has expired."""
+    client = boto3.client("resourcegroupstaggingapi")
+    paginator = client.get_paginator("get_resources")
+
+    stale: list[dict] = []
+    now = datetime.now(tz=UTC)
+
+    for page in paginator.paginate(
+        TagFilters=[{"Key": "AutoDelete", "Values": ["true"]}],
+    ):
+        for resource in page.get("ResourceTagMappingList", []):
+            tags = {t["Key"]: t["Value"] for t in resource.get("Tags", [])}
+            delete_after = tags.get("AutoDeleteAfter")
+            if not delete_after:
+                continue
+
+            try:
+                expiry = datetime.fromisoformat(delete_after)
+            except ValueError:
+                logger.warning(
+                    "Invalid AutoDeleteAfter value '%s' on %s",
+                    delete_after,
+                    resource["ResourceARN"],
+                )
+                continue
+
+            if now > expiry:
+                stale.append(
+                    {
+                        "arn": resource["ResourceARN"],
+                        "auto_delete_after": delete_after,
+                        "age_hours": round((now - expiry).total_seconds() / 3600, 1),
+                    }
+                )
+
+    return stale
+
+
+def handle(event, context):
+    """Lambda entry point.
+
+    Returns a summary of stale resources found. Actual deletion
+    is a placeholder for future implementation.
+    """
+    logger.info("Starting stale resource scan")
+
+    stale_resources = _find_stale_resources()
+
+    for res in stale_resources:
+        logger.info(
+            "STALE: %s (expired %s, %.1f hours ago)",
+            res["arn"],
+            res["auto_delete_after"],
+            res["age_hours"],
+        )
+
+    # TODO: Implement actual deletion logic for ECS tasks, EC2 instances
+    logger.info("Found %d stale resources", len(stale_resources))
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(
+            {
+                "stale_count": len(stale_resources),
+                "resources": stale_resources,
+            }
+        ),
+    }

--- a/tests/test_stale_cleanup_handler.py
+++ b/tests/test_stale_cleanup_handler.py
@@ -7,19 +7,26 @@ interface for the Lambda runtime.
 import importlib
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 # Add lambda/stale_cleanup to sys.path so we can import the handler
 HANDLER_DIR = Path(__file__).resolve().parent.parent / "lambda" / "stale_cleanup"
 
 
 def _import_handler():
-    """Import the handler module from lambda/stale_cleanup/."""
+    """Import the handler module from lambda/stale_cleanup/.
+
+    Injects a mock boto3 so the module can be imported without
+    the real AWS SDK installed.
+    """
+    mock_boto3 = MagicMock()
     sys.path.insert(0, str(HANDLER_DIR))
     try:
         if "handler" in sys.modules:
             del sys.modules["handler"]
-        return importlib.import_module("handler")
+        with patch.dict(sys.modules, {"boto3": mock_boto3}):
+            mod = importlib.import_module("handler")
+        return mod
     finally:
         sys.path.pop(0)
 
@@ -51,11 +58,12 @@ def test_handler_has_handle_function():
 # ---------------------------------------------------------------------------
 
 
-@patch("handler.boto3")
-def test_handler_returns_expected_response_format(mock_boto3):
+def test_handler_returns_expected_response_format():
     """handle() must return a dict with 'statusCode' and 'body' keys."""
-    mock_boto3.client.return_value.get_paginator.return_value.paginate.return_value = []
     mod = _import_handler()
+    mock_boto3 = MagicMock()
+    mock_boto3.client.return_value.get_paginator.return_value.paginate.return_value = []
+    mod.boto3 = mock_boto3
     result = mod.handle({}, {})
     assert isinstance(result, dict), "handle() must return a dict"
     assert "statusCode" in result, "response must contain 'statusCode'"

--- a/tests/test_stale_cleanup_handler.py
+++ b/tests/test_stale_cleanup_handler.py
@@ -1,0 +1,62 @@
+"""Stale resource cleanup Lambda handler tests.
+
+Validates that the handler module exists and exposes the expected
+interface for the Lambda runtime.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Add lambda/stale_cleanup to sys.path so we can import the handler
+HANDLER_DIR = Path(__file__).resolve().parent.parent / "lambda" / "stale_cleanup"
+
+
+def _import_handler():
+    """Import the handler module from lambda/stale_cleanup/."""
+    sys.path.insert(0, str(HANDLER_DIR))
+    try:
+        if "handler" in sys.modules:
+            del sys.modules["handler"]
+        return importlib.import_module("handler")
+    finally:
+        sys.path.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Module existence
+# ---------------------------------------------------------------------------
+
+
+def test_handler_module_exists():
+    """lambda/stale_cleanup/handler.py must exist."""
+    assert (HANDLER_DIR / "handler.py").is_file(), "lambda/stale_cleanup/handler.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Interface
+# ---------------------------------------------------------------------------
+
+
+def test_handler_has_handle_function():
+    """handler module must expose a 'handle' function."""
+    mod = _import_handler()
+    assert hasattr(mod, "handle"), "handler module must have a 'handle' function"
+    assert callable(mod.handle), "'handle' must be callable"
+
+
+# ---------------------------------------------------------------------------
+# Response format
+# ---------------------------------------------------------------------------
+
+
+@patch("handler.boto3")
+def test_handler_returns_expected_response_format(mock_boto3):
+    """handle() must return a dict with 'statusCode' and 'body' keys."""
+    mock_boto3.client.return_value.get_paginator.return_value.paginate.return_value = []
+    mod = _import_handler()
+    result = mod.handle({}, {})
+    assert isinstance(result, dict), "handle() must return a dict"
+    assert "statusCode" in result, "response must contain 'statusCode'"
+    assert "body" in result, "response must contain 'body'"

--- a/tests/test_stale_cleanup_infra.py
+++ b/tests/test_stale_cleanup_infra.py
@@ -1,0 +1,95 @@
+"""Stale resource cleanup infrastructure source-level tests.
+
+Since we cannot run ``pulumi up`` in CI, these tests validate that the
+infrastructure source code defines the expected AWS resources for stale
+resource cleanup using "myxo" naming throughout.
+"""
+
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+
+
+# ---------------------------------------------------------------------------
+# Module existence
+# ---------------------------------------------------------------------------
+
+
+def test_stale_cleanup_module_exists():
+    """infra/stale_cleanup.py must exist."""
+    assert (INFRA_DIR / "stale_cleanup.py").is_file(), "infra/stale_cleanup.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Resource definitions in stale_cleanup.py
+# ---------------------------------------------------------------------------
+
+
+def _stale_cleanup_source() -> str:
+    return (INFRA_DIR / "stale_cleanup.py").read_text()
+
+
+def test_defines_lambda_function():
+    """stale_cleanup.py must define a Lambda Function resource."""
+    src = _stale_cleanup_source()
+    assert "aws.lambda_.Function(" in src, "stale_cleanup.py must define aws.lambda_.Function"
+
+
+def test_defines_eventbridge_schedule_rule():
+    """stale_cleanup.py must define an EventBridge schedule rule."""
+    src = _stale_cleanup_source()
+    assert "cloudwatch.EventRule(" in src, "stale_cleanup.py must define cloudwatch.EventRule"
+
+
+def test_defines_eventbridge_target():
+    """stale_cleanup.py must define an EventBridge target."""
+    src = _stale_cleanup_source()
+    assert "cloudwatch.EventTarget(" in src, "stale_cleanup.py must define cloudwatch.EventTarget"
+
+
+def test_defines_iam_role():
+    """stale_cleanup.py must define an IAM role for the Lambda function."""
+    src = _stale_cleanup_source()
+    assert "iam.Role(" in src, "stale_cleanup.py must define iam.Role"
+
+
+def test_defines_cloudwatch_log_group():
+    """stale_cleanup.py must define a CloudWatch Log Group for Lambda logs."""
+    src = _stale_cleanup_source()
+    assert "cloudwatch.LogGroup(" in src, "stale_cleanup.py must define cloudwatch.LogGroup"
+
+
+def test_myxo_naming():
+    """Key resources must include 'myxo' in their names."""
+    src = _stale_cleanup_source()
+    assert "myxo-stale-cleanup" in src, "Lambda function must use myxo-stale-cleanup name"
+
+
+def test_no_pseudopod_references():
+    """All resource names must use 'myxo', not 'pseudopod'."""
+    src = _stale_cleanup_source()
+    assert "pseudopod" not in src.lower()
+
+
+def test_lambda_runtime_python313():
+    """Lambda function must use python3.13 runtime."""
+    src = _stale_cleanup_source()
+    assert "python3.13" in src, "Lambda must use python3.13 runtime"
+
+
+def test_lambda_timeout_300():
+    """Lambda function must have 300s timeout."""
+    src = _stale_cleanup_source()
+    assert "300" in src, "Lambda must have 300s timeout"
+
+
+def test_schedule_expression():
+    """EventBridge rule must schedule daily at 03:00 UTC."""
+    src = _stale_cleanup_source()
+    assert "cron(0 3 * * ? *)" in src, "EventBridge rule must run daily at 03:00 UTC"
+
+
+def test_main_imports_stale_cleanup_module():
+    """__main__.py must import or reference the stale_cleanup module."""
+    main_src = (INFRA_DIR / "__main__.py").read_text()
+    assert "stale_cleanup" in main_src, "__main__.py must import stale_cleanup module"


### PR DESCRIPTION
## Summary
- Add infra/stale_cleanup.py Pulumi module defining Lambda function (myxo-stale-cleanup), IAM role, CloudWatch Log Group, EventBridge schedule rule (daily 03:00 UTC), and EventBridge target
- Add lambda/stale_cleanup/handler.py stub that scans for AutoDelete=true / AutoDeleteAfter tagged resources and logs expired ones
- Add source-level tests for both infra resources and handler interface (15 tests)
- Import stale_cleanup in infra/__main__.py

Closes #75