### PR TITLE
feat: ✨ add Rust CI coverage and parallel jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,15 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/rust.yml"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -24,5 +31,18 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
-      - name: Test
-        run: cargo test --all
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: "1.85.0"
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@328a871ad8f62ecac78390391f463ccabc974b72 # main
+        with:
+          tool: cargo-llvm-cov
+      - name: Test with coverage
+        run: cargo llvm-cov --all --fail-under-lines 80

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,4 +45,4 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Test with coverage
-        run: cargo llvm-cov --all --fail-under-lines 80
+        run: cargo llvm-cov --workspace --fail-under-lines 80

--- a/tests/test_rust_ci_workflow.py
+++ b/tests/test_rust_ci_workflow.py
@@ -1,0 +1,109 @@
+"""Tests for Rust CI workflow configuration."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "rust.yml"
+
+
+def _load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def _get_on_block(data: dict) -> dict:
+    return data.get(True, data.get("on", {}))
+
+
+def _is_sha_pinned(ref: str) -> bool:
+    _, _, version = ref.partition("@")
+    return bool(re.fullmatch(r"[0-9a-f]{40}", version))
+
+
+# ── structure ──
+
+
+def test_workflow_file_exists():
+    assert WORKFLOW_PATH.is_file()
+
+
+def test_has_permissions_block():
+    data = _load_workflow()
+    permissions = data.get("permissions", {})
+    assert permissions.get("contents") == "read", "Must declare contents: read"
+
+
+def test_has_concurrency_block():
+    data = _load_workflow()
+    assert "concurrency" in data, "Must have concurrency block"
+    concurrency = data["concurrency"]
+    assert "group" in concurrency
+    assert concurrency.get("cancel-in-progress") is True
+
+
+def test_triggers_on_pull_request_with_paths():
+    data = _load_workflow()
+    on_block = _get_on_block(data)
+    pr = on_block.get("pull_request", {})
+    paths = pr.get("paths", [])
+    assert "crates/**" in paths
+    assert "Cargo.toml" in paths
+
+
+# ── jobs: lint (fmt + clippy) ──
+
+
+def test_has_lint_job():
+    data = _load_workflow()
+    assert "lint" in data["jobs"], "Must have separate lint job"
+
+
+def test_lint_job_runs_fmt():
+    data = _load_workflow()
+    steps = data["jobs"]["lint"].get("steps", [])
+    run_cmds = [s["run"] for s in steps if "run" in s]
+    assert any("cargo fmt" in cmd for cmd in run_cmds)
+
+
+def test_lint_job_runs_clippy():
+    data = _load_workflow()
+    steps = data["jobs"]["lint"].get("steps", [])
+    run_cmds = [s["run"] for s in steps if "run" in s]
+    assert any("cargo clippy" in cmd for cmd in run_cmds)
+
+
+# ── jobs: test (with coverage) ──
+
+
+def test_has_test_job():
+    data = _load_workflow()
+    assert "test" in data["jobs"], "Must have separate test job"
+
+
+def test_test_job_uses_llvm_cov():
+    data = _load_workflow()
+    steps = data["jobs"]["test"].get("steps", [])
+    run_cmds = [s["run"] for s in steps if "run" in s]
+    uses_refs = [s["uses"] for s in steps if "uses" in s]
+    has_llvm_cov = any("llvm-cov" in cmd for cmd in run_cmds) or any("cargo-llvm-cov" in u for u in uses_refs)
+    assert has_llvm_cov, "test job must use cargo-llvm-cov for coverage"
+
+
+def test_test_job_enforces_coverage_threshold():
+    data = _load_workflow()
+    steps = data["jobs"]["test"].get("steps", [])
+    run_cmds = [s["run"] for s in steps if "run" in s]
+    assert any("fail-under-lines" in cmd for cmd in run_cmds), "Must enforce coverage threshold"
+
+
+# ── SHA pinning ──
+
+
+def test_all_actions_sha_pinned():
+    data = _load_workflow()
+    for job in data.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            uses = step.get("uses", "")
+            if uses and "/" in uses:
+                assert _is_sha_pinned(uses), f"Action must be SHA-pinned, got: {uses}"

--- a/tests/test_rust_ci_workflow.py
+++ b/tests/test_rust_ci_workflow.py
@@ -9,7 +9,9 @@ WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "rust.y
 
 
 def _load_workflow() -> dict:
-    return yaml.safe_load(WORKFLOW_PATH.read_text())
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    assert isinstance(data, dict), "Workflow YAML must be a valid mapping"
+    return data
 
 
 def _get_on_block(data: dict) -> dict:


### PR DESCRIPTION
## Summary
Split rust.yml into parallel `lint` (fmt + clippy) and `test` (cargo-llvm-cov) jobs for faster CI feedback. Add cargo-llvm-cov with 80% line coverage threshold. Add missing permissions and concurrency blocks to align with other hardened workflows.

Closes #197