### PR TITLE
chore: 🔧 add Taskfile for unified task runner

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,71 @@
+version: "3"
+
+vars:
+  PYTHON_SRC: src/ tests/
+  COVERAGE_THRESHOLD: "80"
+
+tasks:
+  # ── Python ──
+  py:lint:
+    desc: Ruff lint check
+    cmd: uv run ruff check {{.PYTHON_SRC}}
+
+  py:fmt:
+    desc: Ruff format check
+    cmd: uv run ruff format --check {{.PYTHON_SRC}}
+
+  py:fmt:fix:
+    desc: Ruff auto-format
+    cmd: uv run ruff format {{.PYTHON_SRC}}
+
+  py:typecheck:
+    desc: Type check with ty
+    cmd: uv run ty check src/
+
+  py:test:
+    desc: Run pytest with coverage
+    cmd: uv run pytest -m "small or medium" --cov=src/myxo --cov-report=term-missing --cov-fail-under={{.COVERAGE_THRESHOLD}}
+
+  # ── Rust ──
+  rust:fmt:
+    desc: Check Rust formatting
+    cmd: cargo fmt --all -- --check
+
+  rust:fmt:fix:
+    desc: Auto-format Rust code
+    cmd: cargo fmt --all
+
+  rust:lint:
+    desc: Run clippy
+    cmd: cargo clippy --all-targets -- -D warnings
+
+  rust:test:
+    desc: Run Rust tests
+    cmd: cargo test --workspace
+
+  rust:cov:
+    desc: Run Rust tests with coverage
+    cmd: cargo llvm-cov --workspace --fail-under-lines {{.COVERAGE_THRESHOLD}}
+
+  # ── Aggregate ──
+  lint:
+    desc: Lint all (Python + Rust)
+    deps: [py:lint, py:fmt, py:typecheck, rust:fmt, rust:lint]
+
+  test:
+    desc: Test all (Python + Rust)
+    deps: [py:test, rust:test]
+
+  fmt:
+    desc: Auto-format all
+    deps: [py:fmt:fix, rust:fmt:fix]
+
+  check:
+    desc: Full CI check (lint + test)
+    cmds:
+      - task: lint
+      - task: test
+
+  verify:
+    desc: Run mxl verify
+    cmd: uv run mxl verify

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,8 +15,10 @@ tasks:
     cmd: uv run ruff format --check {{.PYTHON_SRC}}
 
   py:fmt:fix:
-    desc: Ruff auto-format
-    cmd: uv run ruff format {{.PYTHON_SRC}}
+    desc: Ruff auto-fix and format
+    cmds:
+      - uv run ruff check --fix {{.PYTHON_SRC}}
+      - uv run ruff format {{.PYTHON_SRC}}
 
   py:typecheck:
     desc: Type check with ty

--- a/tests/test_taskfile.py
+++ b/tests/test_taskfile.py
@@ -29,14 +29,12 @@ class TestTaskfileStructure:
     def test_taskfile_exists(self) -> None:
         assert TASKFILE.exists(), "Taskfile.yml must exist at project root"
 
-    def test_valid_yaml(self) -> None:
-        content = TASKFILE.read_text()
-        data = yaml.safe_load(content)
-        assert isinstance(data, dict)
+    def test_valid_yaml(self, taskfile: dict) -> None:
+        assert isinstance(taskfile, dict)
 
     def test_has_version(self, taskfile: dict) -> None:
         assert "version" in taskfile
-        assert taskfile["version"] == "3"
+        assert taskfile["version"] in (3, "3")
 
     def test_has_tasks_section(self, taskfile: dict) -> None:
         assert "tasks" in taskfile

--- a/tests/test_taskfile.py
+++ b/tests/test_taskfile.py
@@ -1,0 +1,70 @@
+"""Taskfile.yml structure tests.
+
+Verify that the project Taskfile exists, is valid YAML,
+and declares the expected top-level and namespaced tasks.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+TASKFILE = ROOT / "Taskfile.yml"
+
+
+@pytest.fixture()
+def taskfile() -> dict:
+    """Load and return parsed Taskfile."""
+    assert TASKFILE.exists(), "Taskfile.yml must exist at project root"
+    content = TASKFILE.read_text()
+    data = yaml.safe_load(content)
+    assert isinstance(data, dict), "Taskfile.yml must be a valid YAML mapping"
+    return data
+
+
+class TestTaskfileStructure:
+    """Taskfile top-level structure."""
+
+    def test_taskfile_exists(self) -> None:
+        assert TASKFILE.exists(), "Taskfile.yml must exist at project root"
+
+    def test_valid_yaml(self) -> None:
+        content = TASKFILE.read_text()
+        data = yaml.safe_load(content)
+        assert isinstance(data, dict)
+
+    def test_has_version(self, taskfile: dict) -> None:
+        assert "version" in taskfile
+        assert taskfile["version"] == "3"
+
+    def test_has_tasks_section(self, taskfile: dict) -> None:
+        assert "tasks" in taskfile
+
+
+class TestRequiredTopLevelTasks:
+    """Required aggregate tasks."""
+
+    REQUIRED = ["lint", "test", "fmt", "check", "verify"]
+
+    @pytest.mark.parametrize("task_name", REQUIRED)
+    def test_top_level_task_exists(self, taskfile: dict, task_name: str) -> None:
+        tasks = taskfile["tasks"]
+        assert task_name in tasks, f"Missing required top-level task: {task_name}"
+
+
+class TestNamespacedTasks:
+    """Python and Rust namespaced tasks."""
+
+    PY_TASKS = ["py:lint", "py:fmt", "py:fmt:fix", "py:typecheck", "py:test"]
+    RUST_TASKS = ["rust:fmt", "rust:fmt:fix", "rust:lint", "rust:test", "rust:cov"]
+
+    @pytest.mark.parametrize("task_name", PY_TASKS)
+    def test_python_task_exists(self, taskfile: dict, task_name: str) -> None:
+        tasks = taskfile["tasks"]
+        assert task_name in tasks, f"Missing Python task: {task_name}"
+
+    @pytest.mark.parametrize("task_name", RUST_TASKS)
+    def test_rust_task_exists(self, taskfile: dict, task_name: str) -> None:
+        tasks = taskfile["tasks"]
+        assert task_name in tasks, f"Missing Rust task: {task_name}"


### PR DESCRIPTION
## Summary
- Introduce Taskfile.yml (go-task) to unify Python and Rust development commands under a single task runner
- Define namespaced tasks for Python (py:lint, py:fmt, py:typecheck, py:test) and Rust (rust:fmt, rust:lint, rust:test, rust:cov)
- Add aggregate tasks (lint, test, fmt, check, verify) for running cross-language operations
- Add structure tests to validate Taskfile presence, YAML validity, and required task definitions

Closes #202