### PR TITLE
fix: 🐛 replace setup-uv with setup-python in pr-title-lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,10 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
-          enable-cache: true
       - env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: python .github/scripts/pr-title-lint.py "$PR_TITLE"


### PR DESCRIPTION
## Summary
Replace `astral-sh/setup-uv` with `actions/setup-python@v6` in the PR title lint workflow. `setup-uv` is unnecessary for running a single Python script and its cache causes CI failures.