### PR TITLE
feat: ✨ add config.yaml parser with serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,16 +161,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -191,6 +219,11 @@ dependencies = [
 [[package]]
 name = "myxo-core"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_yaml",
+ "thiserror",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -291,12 +324,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -317,6 +357,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -343,10 +396,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/crates/myxo-core/Cargo.toml
+++ b/crates/myxo-core/Cargo.toml
@@ -7,3 +7,8 @@ rust-version.workspace = true
 [lib]
 name = "myxo_core"
 path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+thiserror = "2"

--- a/crates/myxo-core/src/config.rs
+++ b/crates/myxo-core/src/config.rs
@@ -1,4 +1,58 @@
-// Config module - to be implemented
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to read config file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to parse config YAML: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MyxoConfig {
+    pub version: String,
+    #[serde(default)]
+    pub github: Option<GitHubConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubConfig {
+    pub repo: String,
+    #[serde(default)]
+    pub labels: Vec<LabelConfig>,
+    #[serde(default)]
+    pub branch_protection: Option<BranchProtectionConfig>,
+    #[serde(default)]
+    pub secrets: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LabelConfig {
+    pub name: String,
+    pub color: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BranchProtectionConfig {
+    pub branch: String,
+    #[serde(default)]
+    pub required_reviews: u32,
+    #[serde(default)]
+    pub dismiss_stale_reviews: bool,
+}
+
+impl MyxoConfig {
+    pub fn from_yaml(yaml: &str) -> Result<Self, ConfigError> {
+        Ok(serde_yaml::from_str(yaml)?)
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
+        let content = std::fs::read_to_string(path)?;
+        Self::from_yaml(&content)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/myxo-core/src/config.rs
+++ b/crates/myxo-core/src/config.rs
@@ -138,6 +138,9 @@ github:
         let result = MyxoConfig::from_file(&dir.join("config.yaml"));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("config.yaml"), "error should include the file path");
+        assert!(
+            err.contains("config.yaml"),
+            "error should include the file path"
+        );
     }
 }

--- a/crates/myxo-core/src/config.rs
+++ b/crates/myxo-core/src/config.rs
@@ -1,11 +1,14 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
-    #[error("failed to read config file: {0}")]
-    Io(#[from] std::io::Error),
+    #[error("failed to read {path}: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
     #[error("failed to parse config YAML: {0}")]
     Yaml(#[from] serde_yaml::Error),
 }
@@ -49,7 +52,10 @@ impl MyxoConfig {
     }
 
     pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
-        let content = std::fs::read_to_string(path)?;
+        let content = std::fs::read_to_string(path).map_err(|e| ConfigError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
         Self::from_yaml(&content)
     }
 }
@@ -128,7 +134,10 @@ github:
 
     #[test]
     fn from_file_returns_error_for_missing_file() {
-        let result = MyxoConfig::from_file(std::path::Path::new("/nonexistent/config.yaml"));
+        let dir = std::env::temp_dir().join("myxo-test-nonexistent");
+        let result = MyxoConfig::from_file(&dir.join("config.yaml"));
         assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("config.yaml"), "error should include the file path");
     }
 }

--- a/crates/myxo-core/src/config.rs
+++ b/crates/myxo-core/src/config.rs
@@ -1,0 +1,80 @@
+// Config module - to be implemented
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL_CONFIG: &str = r#"
+version: "0.1"
+"#;
+
+    const FULL_CONFIG: &str = r#"
+version: "0.1"
+github:
+  repo: owner/repo
+  labels:
+    - name: "bug"
+      color: "d73a4a"
+    - name: "enhancement"
+      color: "a2eeef"
+  branch_protection:
+    branch: main
+    required_reviews: 1
+    dismiss_stale_reviews: true
+  secrets:
+    - GITHUB_TOKEN
+    - PULUMI_ACCESS_TOKEN
+"#;
+
+    #[test]
+    fn parse_minimal_config() {
+        let config = MyxoConfig::from_yaml(MINIMAL_CONFIG).unwrap();
+        assert_eq!(config.version, "0.1");
+        assert!(config.github.is_none());
+    }
+
+    #[test]
+    fn parse_full_config() {
+        let config = MyxoConfig::from_yaml(FULL_CONFIG).unwrap();
+        assert_eq!(config.version, "0.1");
+        let github = config.github.unwrap();
+        assert_eq!(github.repo, "owner/repo");
+        assert_eq!(github.labels.len(), 2);
+        assert_eq!(github.labels[0].name, "bug");
+        assert_eq!(github.labels[0].color, "d73a4a");
+    }
+
+    #[test]
+    fn parse_branch_protection() {
+        let config = MyxoConfig::from_yaml(FULL_CONFIG).unwrap();
+        let bp = config.github.unwrap().branch_protection.unwrap();
+        assert_eq!(bp.branch, "main");
+        assert_eq!(bp.required_reviews, 1);
+        assert!(bp.dismiss_stale_reviews);
+    }
+
+    #[test]
+    fn parse_secrets() {
+        let config = MyxoConfig::from_yaml(FULL_CONFIG).unwrap();
+        let secrets = config.github.unwrap().secrets;
+        assert_eq!(secrets, vec!["GITHUB_TOKEN", "PULUMI_ACCESS_TOKEN"]);
+    }
+
+    #[test]
+    fn invalid_yaml_returns_error() {
+        let result = MyxoConfig::from_yaml("{{invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_version_returns_error() {
+        let result = MyxoConfig::from_yaml("github:\n  repo: test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_file_returns_error_for_missing_file() {
+        let result = MyxoConfig::from_file(std::path::Path::new("/nonexistent/config.yaml"));
+        assert!(result.is_err());
+    }
+}

--- a/crates/myxo-core/src/lib.rs
+++ b/crates/myxo-core/src/lib.rs
@@ -2,6 +2,6 @@ pub mod config;
 
 pub fn init() {}
 
-pub fn sync(_target: Option<&str>) {}
+pub fn sync() {}
 
-pub fn verify(_fix: bool) {}
+pub fn verify() {}

--- a/crates/myxo-core/src/lib.rs
+++ b/crates/myxo-core/src/lib.rs
@@ -1,13 +1,7 @@
+pub mod config;
+
 pub fn init() {}
 
-pub fn sync() {}
+pub fn sync(_target: Option<&str>) {}
 
-pub fn verify() {}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn smoke() {
-        // Verify the crate compiles and links correctly
-    }
-}
+pub fn verify(_fix: bool) {}


### PR DESCRIPTION
## Summary
Add `MyxoConfig` parser to `myxo-core` using serde + serde_yaml. Supports parsing `.myxo-lab/config.yaml` with github repo, labels, branch_protection, and secrets configuration. Includes thiserror for structured error handling.

Refs #212