### PR TITLE
chore: 🔧 add developer setup script

### DIFF
--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -29,7 +29,8 @@ cargo build
 
 # Set up pre-commit hooks
 echo "Setting up pre-commit hooks..."
-uv run pre-commit install
+uv tool install pre-commit
+pre-commit install
 
 echo ""
 echo "=== Setup complete! ==="

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Myxo Lab Developer Setup ==="
+
+# Check prerequisites
+missing=()
+for cmd in uv cargo task; do
+  if ! command -v "$cmd" &>/dev/null; then
+    missing+=("$cmd")
+  fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "ERROR: Missing required tools: ${missing[*]}"
+  echo "Install them before running this script."
+  exit 1
+fi
+
+echo "✓ All prerequisites found"
+
+# Install Python dependencies
+echo "Installing Python dependencies..."
+uv sync
+
+# Build Rust workspace
+echo "Building Rust workspace..."
+cargo build
+
+# Set up pre-commit hooks
+echo "Setting up pre-commit hooks..."
+uv run pre-commit install
+
+echo ""
+echo "=== Setup complete! ==="
+echo "Run 'task check' to verify everything works."

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,0 +1,33 @@
+"""Tests for developer setup script."""
+
+import os
+import stat
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "setup-dev.sh"
+
+
+def test_script_exists():
+    assert SCRIPT.is_file(), "scripts/setup-dev.sh must exist"
+
+
+def test_script_is_executable():
+    assert SCRIPT.is_file()
+    mode = os.stat(SCRIPT).st_mode
+    assert mode & stat.S_IXUSR, "setup-dev.sh must be executable"
+
+
+def test_script_has_shebang():
+    content = SCRIPT.read_text()
+    assert content.startswith("#!/"), "setup-dev.sh must start with a shebang"
+
+
+def test_script_uses_strict_mode():
+    content = SCRIPT.read_text()
+    assert "set -euo pipefail" in content
+
+
+def test_script_checks_required_tools():
+    content = SCRIPT.read_text()
+    for tool in ["uv", "cargo", "task"]:
+        assert tool in content, f"setup-dev.sh should check for {tool}"


### PR DESCRIPTION
## Summary
Add `scripts/setup-dev.sh` that checks prerequisites (uv, cargo, task), installs Python deps, builds Rust workspace, and sets up pre-commit hooks. Completes the onboarding workflow started in PR #220.

Closes #209