### PR TITLE
feat: ✨ add Rust build stage to Dockerfile

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "container/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
 
 permissions:
   contents: read
@@ -26,7 +29,8 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          context: container/
+          context: .
+          file: container/Dockerfile
           push: false
           load: true
           tags: myxo-lab:test

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,7 @@
 # ============================================================
 # Stage 1: Install Nix and devbox, then run devbox install
 # ============================================================
-FROM debian:bookworm-slim AS builder
+FROM debian:bookworm-slim AS nix-builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -25,13 +25,41 @@ RUN curl -fsSL https://get.jetify.com/devbox | bash -s -- -f
 
 WORKDIR /app
 
-COPY devbox.json ./
+COPY container/devbox.json ./
 
 # Run devbox install to set up A-layer tools
 RUN devbox install
 
 # ============================================================
-# Stage 2: Final minimal image with devbox environment
+# Stage 2: Build Rust binary
+# ============================================================
+FROM rust:1.85-slim-bookworm AS rust-builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Cache dependencies by building with empty src first
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/myxo-cli/Cargo.toml crates/myxo-cli/Cargo.toml
+COPY crates/myxo-core/Cargo.toml crates/myxo-core/Cargo.toml
+
+RUN mkdir -p crates/myxo-cli/src crates/myxo-core/src \
+    && echo 'fn main() {}' > crates/myxo-cli/src/main.rs \
+    && echo '' > crates/myxo-core/src/lib.rs \
+    && cargo build --release --locked -p myxo-cli \
+    && rm -rf crates/
+
+# Copy actual source and build
+COPY crates/ crates/
+RUN cargo build --release --locked -p myxo-cli
+
+# ============================================================
+# Stage 3: Final minimal image with devbox environment + mxl
 # ============================================================
 FROM debian:bookworm-slim
 
@@ -42,11 +70,14 @@ RUN apt-get update \
         xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Nix store and profiles from builder
-COPY --from=builder /nix /nix
-COPY --from=builder /root/.nix-profile /root/.nix-profile
-COPY --from=builder /usr/local/bin/devbox /usr/local/bin/devbox
-COPY --from=builder /app /app
+# Copy Nix store and profiles from nix-builder
+COPY --from=nix-builder /nix /nix
+COPY --from=nix-builder /root/.nix-profile /root/.nix-profile
+COPY --from=nix-builder /usr/local/bin/devbox /usr/local/bin/devbox
+COPY --from=nix-builder /app /app
+
+# Copy mxl binary from rust-builder
+COPY --from=rust-builder /build/target/release/mxl /usr/local/bin/mxl
 
 ENV PATH="/root/.nix-profile/bin:${PATH}"
 

--- a/tests/test_rust_dockerfile.py
+++ b/tests/test_rust_dockerfile.py
@@ -9,15 +9,17 @@ def test_dockerfile_exists():
     assert DOCKERFILE.is_file()
 
 
-def test_has_rust_build_stage():
-    content = DOCKERFILE.read_text()
-    assert "rust:" in content.lower() or "cargo build" in content.lower(), "Dockerfile must have a Rust build stage"
+def test_has_rust_builder_stage():
+    content = DOCKERFILE.read_text().lower()
+    assert "from rust:" in content and "as rust-builder" in content, (
+        "Dockerfile must have a 'FROM rust:... AS rust-builder' stage"
+    )
 
 
 def test_has_multi_stage_build():
     content = DOCKERFILE.read_text()
     from_count = content.lower().count("from ")
-    assert from_count >= 3, "Dockerfile must have at least 3 stages (nix builder, rust builder, final)"
+    assert from_count >= 3, "Dockerfile must have at least 3 stages"
 
 
 def test_copies_rust_binary():
@@ -26,9 +28,13 @@ def test_copies_rust_binary():
 
 
 def test_final_stage_is_minimal():
-    """Final stage should use a slim/distroless base, not a full Rust image."""
     lines = DOCKERFILE.read_text().splitlines()
-    last_from = [l for l in lines if l.strip().upper().startswith("FROM")][-1]
+    last_from = [l for l in lines if l.strip().upper().startswith("FROM")][-1].lower()
     assert "slim" in last_from or "distroless" in last_from or "alpine" in last_from, (
         f"Final stage should use a minimal base image, got: {last_from}"
     )
+
+
+def test_uses_locked_build():
+    content = DOCKERFILE.read_text()
+    assert "--locked" in content, "Rust build should use --locked for reproducibility"

--- a/tests/test_rust_dockerfile.py
+++ b/tests/test_rust_dockerfile.py
@@ -29,7 +29,7 @@ def test_copies_rust_binary():
 
 def test_final_stage_is_minimal():
     lines = DOCKERFILE.read_text().splitlines()
-    last_from = [l for l in lines if l.strip().upper().startswith("FROM")][-1].lower()
+    last_from = [line for line in lines if line.strip().upper().startswith("FROM")][-1].lower()
     assert "slim" in last_from or "distroless" in last_from or "alpine" in last_from, (
         f"Final stage should use a minimal base image, got: {last_from}"
     )

--- a/tests/test_rust_dockerfile.py
+++ b/tests/test_rust_dockerfile.py
@@ -1,0 +1,34 @@
+"""Tests for Rust binary Dockerfile."""
+
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).resolve().parent.parent / "container" / "Dockerfile"
+
+
+def test_dockerfile_exists():
+    assert DOCKERFILE.is_file()
+
+
+def test_has_rust_build_stage():
+    content = DOCKERFILE.read_text()
+    assert "rust:" in content.lower() or "cargo build" in content.lower(), "Dockerfile must have a Rust build stage"
+
+
+def test_has_multi_stage_build():
+    content = DOCKERFILE.read_text()
+    from_count = content.lower().count("from ")
+    assert from_count >= 3, "Dockerfile must have at least 3 stages (nix builder, rust builder, final)"
+
+
+def test_copies_rust_binary():
+    content = DOCKERFILE.read_text()
+    assert "mxl" in content, "Dockerfile must reference the mxl binary"
+
+
+def test_final_stage_is_minimal():
+    """Final stage should use a slim/distroless base, not a full Rust image."""
+    lines = DOCKERFILE.read_text().splitlines()
+    last_from = [l for l in lines if l.strip().upper().startswith("FROM")][-1]
+    assert "slim" in last_from or "distroless" in last_from or "alpine" in last_from, (
+        f"Final stage should use a minimal base image, got: {last_from}"
+    )


### PR DESCRIPTION
## Summary
Add Rust multi-stage build to container Dockerfile. Uses `rust:1.85-slim-bookworm` with dependency caching (empty src trick). Copies `mxl` binary to final `debian:bookworm-slim` image alongside existing Nix/devbox environment.

Refs #212