### PR TITLE
perf: ⚡️ optimize container build CI triggers

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -5,15 +5,16 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "container/**"
-      - "crates/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
+      - ".github/workflows/container-build.yml"
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 concurrency:
-  group: container-build-${{ github.head_ref }}
+  group: container-build-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/tests/test_container_build_workflow.py
+++ b/tests/test_container_build_workflow.py
@@ -26,14 +26,16 @@ def test_workflow_is_valid_yaml():
     assert isinstance(data, dict), "Workflow must be a valid YAML mapping"
 
 
-def test_pr_trigger_only_on_container_changes():
-    """PR trigger should only fire on container/** changes, not crates/**."""
+def test_pr_trigger_excludes_rust_paths():
+    """PR trigger should include container/** but exclude Rust paths (verified by rust.yml)."""
     data = _load_workflow()
     on_block = _get_on_block(data)
     pr_trigger = on_block.get("pull_request", {})
     paths = pr_trigger.get("paths", [])
     assert "container/**" in paths, "Must filter on container/** path"
     assert "crates/**" not in paths, "crates/** should not trigger container build on PR"
+    assert "Cargo.toml" not in paths, "Cargo.toml should not trigger container build on PR"
+    assert "Cargo.lock" not in paths, "Cargo.lock should not trigger container build on PR"
 
 
 def test_push_to_main_triggers_build():

--- a/tests/test_container_build_workflow.py
+++ b/tests/test_container_build_workflow.py
@@ -26,13 +26,23 @@ def test_workflow_is_valid_yaml():
     assert isinstance(data, dict), "Workflow must be a valid YAML mapping"
 
 
-def test_triggers_on_pull_request_with_paths_filter():
+def test_pr_trigger_only_on_container_changes():
+    """PR trigger should only fire on container/** changes, not crates/**."""
     data = _load_workflow()
     on_block = _get_on_block(data)
     pr_trigger = on_block.get("pull_request", {})
-    assert pr_trigger is not None, "Must trigger on pull_request"
     paths = pr_trigger.get("paths", [])
     assert "container/**" in paths, "Must filter on container/** path"
+    assert "crates/**" not in paths, "crates/** should not trigger container build on PR"
+
+
+def test_push_to_main_triggers_build():
+    """Push to main should trigger container build for full verification."""
+    data = _load_workflow()
+    on_block = _get_on_block(data)
+    push_trigger = on_block.get("push", {})
+    branches = push_trigger.get("branches", [])
+    assert "main" in branches, "Must trigger on push to main"
 
 
 def test_pull_request_trigger_types():


### PR DESCRIPTION
## Summary
Remove `crates/**` and `Cargo.*` from PR paths filter — Rust code quality is already verified by `rust.yml`. Add `push` to `main` trigger so full Docker build + trivy scan runs on every merge. This eliminates ~7-10 min container builds on Rust-only PR changes.

| Trigger | Before | After |
|---------|--------|-------|
| PR + `crates/**` | Docker build (7-10 min) | No container build |
| PR + `container/**` | Docker build | Docker build (unchanged) |
| Push to `main` | No build | Docker build + trivy |