### PR TITLE
feat: ✨ implement sanitizer and rules validator in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ name = "myxo-core"
 version = "0.1.0"
 dependencies = [
  "octocrab",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/myxo-core/Cargo.toml
+++ b/crates/myxo-core/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 octocrab = "0.44"
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/myxo-core/src/lib.rs
+++ b/crates/myxo-core/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod config;
 pub mod frontmatter;
+pub mod rules_validator;
+pub mod sanitizer;
 pub mod syncer;
 pub mod verifier;
 

--- a/crates/myxo-core/src/rules_validator.rs
+++ b/crates/myxo-core/src/rules_validator.rs
@@ -24,10 +24,10 @@ pub fn validate_rules(content: &str) -> Vec<String> {
     for (i, line) in lines.iter().enumerate() {
         let line_num = i + 1;
 
-        if line.len() > MAX_LINE_LENGTH {
+        let char_count = line.chars().count();
+        if char_count > MAX_LINE_LENGTH {
             errors.push(format!(
-                "Line {line_num}: exceeds {MAX_LINE_LENGTH} characters (found {})",
-                line.len()
+                "Line {line_num}: exceeds {MAX_LINE_LENGTH} characters (found {char_count})"
             ));
         }
 

--- a/crates/myxo-core/src/rules_validator.rs
+++ b/crates/myxo-core/src/rules_validator.rs
@@ -1,4 +1,50 @@
-// Rules validator module - to be implemented
+const MAX_LINES: usize = 50;
+const MAX_LINE_LENGTH: usize = 120;
+
+pub fn validate_rules(content: &str) -> Vec<String> {
+    if content.trim().is_empty() {
+        return vec![];
+    }
+
+    let mut errors = Vec::new();
+    let mut lines: Vec<&str> = content.split('\n').collect();
+
+    // Remove trailing empty line caused by final newline
+    if lines.last() == Some(&"") {
+        lines.pop();
+    }
+
+    if lines.len() > MAX_LINES {
+        errors.push(format!(
+            "rules.md exceeds {MAX_LINES} lines (found {})",
+            lines.len()
+        ));
+    }
+
+    for (i, line) in lines.iter().enumerate() {
+        let line_num = i + 1;
+
+        if line.len() > MAX_LINE_LENGTH {
+            errors.push(format!(
+                "Line {line_num}: exceeds {MAX_LINE_LENGTH} characters (found {})",
+                line.len()
+            ));
+        }
+
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if !line.starts_with("- ") {
+            let preview: String = line.chars().take(40).collect();
+            errors.push(format!(
+                "Line {line_num}: must start with '- ' (bullet point), got: {preview}"
+            ));
+        }
+    }
+
+    errors
+}
 
 #[cfg(test)]
 mod tests {
@@ -27,7 +73,10 @@ mod tests {
 
     #[test]
     fn exceeds_max_lines() {
-        let content = (0..51).map(|i| format!("- Rule {i}")).collect::<Vec<_>>().join("\n");
+        let content = (0..51)
+            .map(|i| format!("- Rule {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
         let errors = validate_rules(&content);
         assert!(errors.iter().any(|e| e.contains("exceeds 50 lines")));
     }

--- a/crates/myxo-core/src/rules_validator.rs
+++ b/crates/myxo-core/src/rules_validator.rs
@@ -1,0 +1,41 @@
+// Rules validator module - to be implemented
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_rules_no_errors() {
+        let content = "# Rules\n\n- Rule one\n- Rule two\n";
+        let errors = validate_rules(content);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn empty_content_no_errors() {
+        let errors = validate_rules("");
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn invalid_line_format() {
+        let content = "# Rules\n\nNot a bullet line\n";
+        let errors = validate_rules(content);
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("must start with '- '"));
+    }
+
+    #[test]
+    fn exceeds_max_lines() {
+        let content = (0..51).map(|i| format!("- Rule {i}")).collect::<Vec<_>>().join("\n");
+        let errors = validate_rules(&content);
+        assert!(errors.iter().any(|e| e.contains("exceeds 50 lines")));
+    }
+
+    #[test]
+    fn exceeds_max_line_length() {
+        let long_line = format!("- {}", "a".repeat(120));
+        let errors = validate_rules(&long_line);
+        assert!(errors.iter().any(|e| e.contains("exceeds 120 characters")));
+    }
+}

--- a/crates/myxo-core/src/sanitizer.rs
+++ b/crates/myxo-core/src/sanitizer.rs
@@ -1,0 +1,45 @@
+// Sanitizer module - to be implemented
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_aws_access_key() {
+        let s = Sanitizer::new();
+        let text = "key = AKIAIOSFODNN7EXAMPLE";
+        let result = s.sanitize(text);
+        assert!(result.contains("[REDACTED:aws-access-key]"));
+        assert!(!result.contains("AKIAIOSFODNN7EXAMPLE"));
+    }
+
+    #[test]
+    fn sanitize_github_token() {
+        let s = Sanitizer::new();
+        let text = "token = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl";
+        let result = s.sanitize(text);
+        assert!(result.contains("[REDACTED:github-token]"));
+    }
+
+    #[test]
+    fn sanitize_jwt() {
+        let s = Sanitizer::new();
+        let text = "auth: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.abc123";
+        let result = s.sanitize(text);
+        assert!(result.contains("[REDACTED:jwt]"));
+    }
+
+    #[test]
+    fn no_secrets_unchanged() {
+        let s = Sanitizer::new();
+        let text = "hello world, no secrets here";
+        assert_eq!(s.sanitize(text), text);
+    }
+
+    #[test]
+    fn has_secrets_detects_key() {
+        let s = Sanitizer::new();
+        assert!(s.has_secrets("key = AKIAIOSFODNN7EXAMPLE"));
+        assert!(!s.has_secrets("just plain text"));
+    }
+}

--- a/crates/myxo-core/src/sanitizer.rs
+++ b/crates/myxo-core/src/sanitizer.rs
@@ -1,4 +1,66 @@
-// Sanitizer module - to be implemented
+use regex::Regex;
+
+struct Pattern {
+    label: &'static str,
+    regex: Regex,
+}
+
+pub struct Sanitizer {
+    patterns: Vec<Pattern>,
+}
+
+impl Sanitizer {
+    pub fn new() -> Self {
+        Self {
+            patterns: vec![
+                Pattern {
+                    label: "aws-access-key",
+                    regex: Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
+                },
+                Pattern {
+                    label: "jwt",
+                    regex: Regex::new(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
+                        .unwrap(),
+                },
+                Pattern {
+                    label: "github-token",
+                    regex: Regex::new(
+                        r"(?:github_pat_[A-Za-z0-9_]{22,}|gh[psourx]_[A-Za-z0-9_]{36,})",
+                    )
+                    .unwrap(),
+                },
+                Pattern {
+                    label: "private-key",
+                    regex: Regex::new(
+                        r"-----BEGIN\s[\w\s]*PRIVATE\sKEY-----[\s\S]*?-----END\s[\w\s]*PRIVATE\sKEY-----",
+                    )
+                    .unwrap(),
+                },
+            ],
+        }
+    }
+
+    pub fn sanitize(&self, text: &str) -> String {
+        let mut result = text.to_string();
+        for p in &self.patterns {
+            result = p
+                .regex
+                .replace_all(&result, format!("[REDACTED:{}]", p.label))
+                .into_owned();
+        }
+        result
+    }
+
+    pub fn has_secrets(&self, text: &str) -> bool {
+        self.patterns.iter().any(|p| p.regex.is_match(text))
+    }
+}
+
+impl Default for Sanitizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/myxo-core/src/sanitizer.rs
+++ b/crates/myxo-core/src/sanitizer.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 struct Pattern {
@@ -5,44 +7,48 @@ struct Pattern {
     regex: Regex,
 }
 
-pub struct Sanitizer {
-    patterns: Vec<Pattern>,
-}
+static PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
+    vec![
+        Pattern {
+            label: "aws-access-key",
+            regex: Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
+        },
+        Pattern {
+            label: "aws-secret-key",
+            regex: Regex::new(
+                r"(?i)(?:aws_secret_access_key|AWS_SECRET_ACCESS_KEY)\s*[=:]\s*[A-Za-z0-9/+=]{40}",
+            )
+            .unwrap(),
+        },
+        Pattern {
+            label: "jwt",
+            regex: Regex::new(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+").unwrap(),
+        },
+        Pattern {
+            label: "github-token",
+            regex: Regex::new(r"(?:github_pat_[A-Za-z0-9_]{22,}|gh[psourx]_[A-Za-z0-9_]{36,})")
+                .unwrap(),
+        },
+        Pattern {
+            label: "private-key",
+            regex: Regex::new(
+                r"-----BEGIN [A-Z ]*PRIVATE KEY-----[^-]+-----END [A-Z ]*PRIVATE KEY-----",
+            )
+            .unwrap(),
+        },
+    ]
+});
+
+pub struct Sanitizer;
 
 impl Sanitizer {
     pub fn new() -> Self {
-        Self {
-            patterns: vec![
-                Pattern {
-                    label: "aws-access-key",
-                    regex: Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
-                },
-                Pattern {
-                    label: "jwt",
-                    regex: Regex::new(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
-                        .unwrap(),
-                },
-                Pattern {
-                    label: "github-token",
-                    regex: Regex::new(
-                        r"(?:github_pat_[A-Za-z0-9_]{22,}|gh[psourx]_[A-Za-z0-9_]{36,})",
-                    )
-                    .unwrap(),
-                },
-                Pattern {
-                    label: "private-key",
-                    regex: Regex::new(
-                        r"-----BEGIN\s[\w\s]*PRIVATE\sKEY-----[\s\S]*?-----END\s[\w\s]*PRIVATE\sKEY-----",
-                    )
-                    .unwrap(),
-                },
-            ],
-        }
+        Self
     }
 
     pub fn sanitize(&self, text: &str) -> String {
         let mut result = text.to_string();
-        for p in &self.patterns {
+        for p in PATTERNS.iter() {
             result = p
                 .regex
                 .replace_all(&result, format!("[REDACTED:{}]", p.label))
@@ -52,7 +58,7 @@ impl Sanitizer {
     }
 
     pub fn has_secrets(&self, text: &str) -> bool {
-        self.patterns.iter().any(|p| p.regex.is_match(text))
+        PATTERNS.iter().any(|p| p.regex.is_match(text))
     }
 }
 
@@ -76,6 +82,14 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_aws_secret_key() {
+        let s = Sanitizer::new();
+        let text = "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        let result = s.sanitize(text);
+        assert!(result.contains("[REDACTED:aws-secret-key]"));
+    }
+
+    #[test]
     fn sanitize_github_token() {
         let s = Sanitizer::new();
         let text = "token = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl";
@@ -89,6 +103,14 @@ mod tests {
         let text = "auth: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.abc123";
         let result = s.sanitize(text);
         assert!(result.contains("[REDACTED:jwt]"));
+    }
+
+    #[test]
+    fn sanitize_private_key() {
+        let s = Sanitizer::new();
+        let text = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJ\n-----END RSA PRIVATE KEY-----";
+        let result = s.sanitize(text);
+        assert!(result.contains("[REDACTED:private-key]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Port remaining Python modules to Rust: ContextSanitizer (secret detection/redaction for AWS keys, JWTs, GitHub tokens, private keys) and rules.md validator (line format, max lines, max line length). This completes the Rust port of all application logic modules.

Note: `secure_filesystem` and `prompt_cache` are infrastructure-specific modules that will be ported when their Rust consumers are implemented.

Refs #212