### PR TITLE
feat: ⚡️ introduce cargo-nextest for test optimization

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.default]
+slow-timeout = { period = "30s", terminate-after = 3 }
+fail-fast = false
+
+[profile.ci]
+fail-fast = true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           tool: cargo-nextest
       - name: Test with coverage
-        run: cargo llvm-cov nextest --workspace --fail-under-lines 80
+        run: cargo llvm-cov nextest --workspace --profile ci --fail-under-lines 80
 
   test-integration:
     runs-on: ubuntu-latest
@@ -62,4 +62,4 @@ jobs:
         with:
           tool: cargo-nextest
       - name: Run all tests including ignored
-        run: cargo nextest run --workspace --run-ignored all
+        run: cargo nextest run --workspace --profile ci --run-ignored all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,5 +44,22 @@ jobs:
       - uses: taiki-e/install-action@328a871ad8f62ecac78390391f463ccabc974b72 # main
         with:
           tool: cargo-llvm-cov
+      - uses: taiki-e/install-action@328a871ad8f62ecac78390391f463ccabc974b72 # main
+        with:
+          tool: cargo-nextest
       - name: Test with coverage
-        run: cargo llvm-cov --workspace --fail-under-lines 80
+        run: cargo llvm-cov nextest --workspace --fail-under-lines 80
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: "1.88.0"
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@328a871ad8f62ecac78390391f463ccabc974b72 # main
+        with:
+          tool: cargo-nextest
+      - name: Run all tests including ignored
+        run: cargo nextest run --workspace --run-ignored all

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,11 @@ tasks:
 
   rust:test:
     desc: Run Rust tests
-    cmd: cargo test --workspace
+    cmd: cargo nextest run --workspace
+
+  rust:test:all:
+    desc: Run all Rust tests including ignored
+    cmd: cargo nextest run --workspace --run-ignored all
 
   rust:cov:
     desc: Run Rust tests with coverage

--- a/tests/test_nextest_config.py
+++ b/tests/test_nextest_config.py
@@ -1,0 +1,136 @@
+"""Tests for cargo-nextest configuration.
+
+Verify that:
+- `.config/nextest.toml` exists and contains valid TOML settings
+- `rust.yml` has a `test-integration` job with `--run-ignored`
+- `Taskfile.yml` has a `rust:test:all` task
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+ROOT = Path(__file__).resolve().parents[1]
+NEXTEST_CONFIG = ROOT / ".config" / "nextest.toml"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "rust.yml"
+TASKFILE = ROOT / "Taskfile.yml"
+
+
+# ── nextest.toml ──
+
+
+class TestNextestConfig:
+    """Validate .config/nextest.toml structure."""
+
+    def test_nextest_config_exists(self) -> None:
+        assert NEXTEST_CONFIG.is_file(), ".config/nextest.toml must exist"
+
+    def test_nextest_config_valid_toml(self) -> None:
+        content = NEXTEST_CONFIG.read_bytes()
+        data = tomllib.loads(content.decode())
+        assert isinstance(data, dict), "nextest.toml must be a valid TOML mapping"
+
+    def test_has_default_profile(self) -> None:
+        data = tomllib.loads(NEXTEST_CONFIG.read_bytes().decode())
+        assert "profile" in data, "nextest.toml must have [profile] section"
+        assert "default" in data["profile"], "Must have [profile.default]"
+
+    def test_default_profile_has_slow_timeout(self) -> None:
+        data = tomllib.loads(NEXTEST_CONFIG.read_bytes().decode())
+        default = data["profile"]["default"]
+        assert "slow-timeout" in default, "default profile must have slow-timeout"
+        timeout = default["slow-timeout"]
+        assert "period" in timeout
+        assert "terminate-after" in timeout
+
+    def test_has_ci_profile(self) -> None:
+        data = tomllib.loads(NEXTEST_CONFIG.read_bytes().decode())
+        assert "ci" in data["profile"], "Must have [profile.ci]"
+
+    def test_ci_profile_fail_fast(self) -> None:
+        data = tomllib.loads(NEXTEST_CONFIG.read_bytes().decode())
+        ci = data["profile"]["ci"]
+        assert ci.get("fail-fast") is True, "CI profile must set fail-fast = true"
+
+
+# ── rust.yml – test-integration job ──
+
+
+class TestRustWorkflowNextest:
+    """Validate rust.yml has nextest integration."""
+
+    @pytest.fixture()
+    def workflow(self) -> dict:
+        data = yaml.safe_load(WORKFLOW_PATH.read_text())
+        assert isinstance(data, dict)
+        return data
+
+    def test_has_test_integration_job(self, workflow: dict) -> None:
+        jobs = workflow.get("jobs", {})
+        assert "test-integration" in jobs, "rust.yml must have test-integration job"
+
+    def test_integration_job_runs_ignored(self, workflow: dict) -> None:
+        job = workflow["jobs"]["test-integration"]
+        steps = job.get("steps", [])
+        run_steps = [s.get("run", "") for s in steps if "run" in s]
+        combined = " ".join(run_steps)
+        assert "--run-ignored" in combined, (
+            "test-integration must use --run-ignored flag"
+        )
+
+    def test_test_job_uses_nextest(self, workflow: dict) -> None:
+        """Test job should use cargo llvm-cov nextest."""
+        job = workflow["jobs"]["test"]
+        steps = job.get("steps", [])
+        run_steps = [s.get("run", "") for s in steps if "run" in s]
+        combined = " ".join(run_steps)
+        assert "nextest" in combined, "test job must use nextest"
+
+    def test_installs_cargo_nextest(self, workflow: dict) -> None:
+        """CI must install cargo-nextest."""
+        job = workflow["jobs"]["test"]
+        steps = job.get("steps", [])
+        tools = []
+        for step in steps:
+            uses = step.get("uses", "")
+            if "install-action" in uses:
+                tool = step.get("with", {}).get("tool", "")
+                tools.append(tool)
+        assert any("cargo-nextest" in t for t in tools), (
+            "Must install cargo-nextest via install-action"
+        )
+
+
+# ── Taskfile – rust:test:all ──
+
+
+class TestTaskfileNextest:
+    """Validate Taskfile has nextest tasks."""
+
+    @pytest.fixture()
+    def taskfile(self) -> dict:
+        data = yaml.safe_load(TASKFILE.read_text())
+        assert isinstance(data, dict)
+        return data
+
+    def test_has_rust_test_all_task(self, taskfile: dict) -> None:
+        tasks = taskfile.get("tasks", {})
+        assert "rust:test:all" in tasks, "Taskfile must have rust:test:all task"
+
+    def test_rust_test_all_runs_ignored(self, taskfile: dict) -> None:
+        task = taskfile["tasks"]["rust:test:all"]
+        cmd = task.get("cmd", "")
+        assert "--run-ignored all" in cmd, (
+            "rust:test:all must use --run-ignored all"
+        )
+
+    def test_rust_test_uses_nextest(self, taskfile: dict) -> None:
+        task = taskfile["tasks"]["rust:test"]
+        cmd = task.get("cmd", "")
+        assert "nextest" in cmd, "rust:test must use cargo nextest"

--- a/tests/test_nextest_config.py
+++ b/tests/test_nextest_config.py
@@ -6,15 +6,11 @@ Verify that:
 - `Taskfile.yml` has a `rust:test:all` task
 """
 
+import tomllib
 from pathlib import Path
 
 import pytest
 import yaml
-
-try:
-    import tomllib
-except ModuleNotFoundError:  # Python < 3.11
-    import tomli as tomllib  # type: ignore[no-redef]
 
 ROOT = Path(__file__).resolve().parents[1]
 NEXTEST_CONFIG = ROOT / ".config" / "nextest.toml"
@@ -80,9 +76,7 @@ class TestRustWorkflowNextest:
         steps = job.get("steps", [])
         run_steps = [s.get("run", "") for s in steps if "run" in s]
         combined = " ".join(run_steps)
-        assert "--run-ignored" in combined, (
-            "test-integration must use --run-ignored flag"
-        )
+        assert "--run-ignored" in combined, "test-integration must use --run-ignored flag"
 
     def test_test_job_uses_nextest(self, workflow: dict) -> None:
         """Test job should use cargo llvm-cov nextest."""
@@ -102,9 +96,7 @@ class TestRustWorkflowNextest:
             if "install-action" in uses:
                 tool = step.get("with", {}).get("tool", "")
                 tools.append(tool)
-        assert any("cargo-nextest" in t for t in tools), (
-            "Must install cargo-nextest via install-action"
-        )
+        assert any("cargo-nextest" in t for t in tools), "Must install cargo-nextest via install-action"
 
 
 # ── Taskfile – rust:test:all ──
@@ -126,9 +118,7 @@ class TestTaskfileNextest:
     def test_rust_test_all_runs_ignored(self, taskfile: dict) -> None:
         task = taskfile["tasks"]["rust:test:all"]
         cmd = task.get("cmd", "")
-        assert "--run-ignored all" in cmd, (
-            "rust:test:all must use --run-ignored all"
-        )
+        assert "--run-ignored all" in cmd, "rust:test:all must use --run-ignored all"
 
     def test_rust_test_uses_nextest(self, taskfile: dict) -> None:
         task = taskfile["tasks"]["rust:test"]


### PR DESCRIPTION
## Summary
- Add `.config/nextest.toml` with default (slow-timeout, fail-fast=false) and ci (fail-fast=true) profiles
- Update `rust.yml` to install cargo-nextest and use `cargo llvm-cov nextest` for coverage
- Add `test-integration` CI job running `cargo nextest run --workspace --run-ignored all`
- Update `Taskfile.yml`: `rust:test` uses nextest, new `rust:test:all` task for ignored tests

Closes #231