### PR TITLE
feat: ✨ add ECS Fargate preview environment

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -5,6 +5,7 @@ import secrets  # noqa: F401 — GitHub Secrets & Environments
 import cleanup  # noqa: F401 — PR cleanup Lambda resources
 import ecs  # noqa: F401 — ECS Fargate resources
 import github_app  # noqa: F401 — GitHub App registration
+import preview  # noqa: F401 — ECS Fargate preview environments
 import pulumi
 import pulumi_github as github
 import stale_cleanup  # noqa: F401 — Stale resource cleanup Lambda + EventBridge

--- a/infra/preview.py
+++ b/infra/preview.py
@@ -1,0 +1,119 @@
+"""ECS Fargate preview environment for PR-specific deployments (#73).
+
+Creates a lightweight ECS service per pull request, allowing API preview
+before merge.  Uses FARGATE_SPOT to keep costs around ~$1/day.
+"""
+
+import pulumi
+import pulumi_aws as aws
+
+import ecs
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+config = pulumi.Config("preview")
+pr_number = config.get_int("pr_number") or 0
+
+
+# ---------------------------------------------------------------------------
+# PreviewEnvironment
+# ---------------------------------------------------------------------------
+class PreviewEnvironment:
+    """PR-specific ECS Fargate preview service.
+
+    Parameters
+    ----------
+    pr_number:
+        Pull-request number used to name and tag resources.
+    cluster_arn:
+        ARN of the existing ECS cluster.
+    task_definition_arn:
+        ARN of the task definition to run.
+    subnet_ids:
+        List of subnet IDs for awsvpc networking.
+    vpc_id:
+        VPC ID for the security group.
+    """
+
+    def __init__(
+        self,
+        pr_number: int,
+        *,
+        cluster_arn: pulumi.Input[str],
+        task_definition_arn: pulumi.Input[str],
+        subnet_ids: list[pulumi.Input[str]],
+        vpc_id: pulumi.Input[str],
+    ) -> None:
+        name = f"myxo-preview-pr-{pr_number}"
+
+        # --- Security Group (allow inbound 8080) ----------------------------
+        self.security_group = aws.ec2.SecurityGroup(
+            f"{name}-sg",
+            name_prefix=f"{name}-",
+            description=f"Preview environment for PR #{pr_number}",
+            vpc_id=vpc_id,
+            ingress=[
+                aws.ec2.SecurityGroupIngressArgs(
+                    protocol="tcp",
+                    from_port=8080,
+                    to_port=8080,
+                    cidr_blocks=["0.0.0.0/0"],
+                    description="API preview port",
+                ),
+            ],
+            egress=[
+                aws.ec2.SecurityGroupEgressArgs(
+                    protocol="-1",
+                    from_port=0,
+                    to_port=0,
+                    cidr_blocks=["0.0.0.0/0"],
+                ),
+            ],
+            tags={"Name": name, "PR": str(pr_number)},
+        )
+
+        # --- ECS Service (Fargate Spot, 1 task) -----------------------------
+        self.service = aws.ecs.Service(
+            f"{name}-svc",
+            name=name,
+            cluster=cluster_arn,
+            task_definition=task_definition_arn,
+            desired_count=1,
+            launch_type="FARGATE",
+            capacity_provider_strategies=[
+                aws.ecs.ServiceCapacityProviderStrategyArgs(
+                    capacity_provider="FARGATE_SPOT",
+                    weight=1,
+                ),
+            ],
+            network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
+                subnets=subnet_ids,
+                security_groups=[self.security_group.id],
+                assign_public_ip=True,
+            ),
+            tags={"PR": str(pr_number)},
+        )
+
+        # --- Export service URL ----------------------------------------------
+        self.service_url = pulumi.Output.concat(
+            "http://", name, ".preview.internal:8080"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Instantiate only when a PR number is provided via config
+# ---------------------------------------------------------------------------
+if pr_number:
+    _vpc_id = config.require("vpc_id")
+    _subnet_ids = config.require_object("subnet_ids")
+
+    preview = PreviewEnvironment(
+        pr_number,
+        cluster_arn=ecs.cluster.arn,
+        task_definition_arn=ecs.task_definition.arn,
+        subnet_ids=_subnet_ids,
+        vpc_id=_vpc_id,
+    )
+
+    pulumi.export("preview_service_url", preview.service_url)

--- a/infra/preview.py
+++ b/infra/preview.py
@@ -4,10 +4,9 @@ Creates a lightweight ECS service per pull request, allowing API preview
 before merge.  Uses FARGATE_SPOT to keep costs around ~$1/day.
 """
 
+import ecs
 import pulumi
 import pulumi_aws as aws
-
-import ecs
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -80,7 +79,6 @@ class PreviewEnvironment:
             cluster=cluster_arn,
             task_definition=task_definition_arn,
             desired_count=1,
-            launch_type="FARGATE",
             capacity_provider_strategies=[
                 aws.ecs.ServiceCapacityProviderStrategyArgs(
                     capacity_provider="FARGATE_SPOT",
@@ -95,10 +93,10 @@ class PreviewEnvironment:
             tags={"PR": str(pr_number)},
         )
 
-        # --- Export service URL ----------------------------------------------
-        self.service_url = pulumi.Output.concat(
-            "http://", name, ".preview.internal:8080"
-        )
+        # --- Export info -------------------------------------------------------
+        # Note: actual URL requires ALB/Cloud Map setup (future work).
+        # For now, access via task public IP on port 8080.
+        self.service_name = name
 
 
 # ---------------------------------------------------------------------------
@@ -116,4 +114,4 @@ if pr_number:
         vpc_id=_vpc_id,
     )
 
-    pulumi.export("preview_service_url", preview.service_url)
+    pulumi.export("preview_service_name", preview.service_name)

--- a/tests/test_preview_infra.py
+++ b/tests/test_preview_infra.py
@@ -1,0 +1,94 @@
+"""ECS Fargate preview environment infrastructure source-level tests.
+
+Validates that the preview environment Pulumi module defines the expected
+resources for PR-specific ECS Fargate services (#73).
+"""
+
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+
+
+def test_preview_module_exists():
+    """infra/preview.py must exist."""
+    assert (INFRA_DIR / "preview.py").is_file(), "infra/preview.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Resource definitions in preview.py
+# ---------------------------------------------------------------------------
+
+
+def _preview_source() -> str:
+    return (INFRA_DIR / "preview.py").read_text()
+
+
+def test_preview_imports_pulumi_aws():
+    """preview.py must import pulumi_aws."""
+    src = _preview_source()
+    assert "pulumi_aws" in src, "preview.py must import pulumi_aws"
+
+
+def test_defines_preview_environment():
+    """preview.py must define PreviewEnvironment class or function."""
+    src = _preview_source()
+    assert "PreviewEnvironment" in src, (
+        "preview.py must define PreviewEnvironment"
+    )
+
+
+def test_defines_ecs_service():
+    """preview.py must define an ECS Service resource."""
+    src = _preview_source()
+    assert "ecs.Service(" in src or "aws.ecs.Service(" in src, (
+        "preview.py must define an ECS Service"
+    )
+
+
+def test_defines_security_group():
+    """preview.py must define a Security Group for inbound traffic."""
+    src = _preview_source()
+    assert "SecurityGroup(" in src, (
+        "preview.py must define a SecurityGroup"
+    )
+
+
+def test_security_group_allows_port_8080():
+    """Security group must allow inbound on port 8080."""
+    src = _preview_source()
+    assert "8080" in src, "Security group must reference port 8080"
+
+
+def test_uses_fargate_spot():
+    """Preview service must use FARGATE_SPOT capacity provider."""
+    src = _preview_source()
+    assert "FARGATE_SPOT" in src, "Preview service must use FARGATE_SPOT"
+
+
+def test_desired_count_is_one():
+    """Preview service desired_count must be 1."""
+    src = _preview_source()
+    assert "desired_count=1" in src, "Preview service desired_count must be 1"
+
+
+def test_parameterized_by_pr_number():
+    """PreviewEnvironment must accept a PR number parameter."""
+    src = _preview_source()
+    assert "pr_number" in src, (
+        "PreviewEnvironment must be parameterized by pr_number"
+    )
+
+
+def test_exports_service_url():
+    """preview.py must export the service URL."""
+    src = _preview_source()
+    assert "pulumi.export(" in src, "preview.py must export a value"
+    assert "url" in src.lower(), "preview.py must export a URL"
+
+
+def test_main_imports_preview_module():
+    """__main__.py must import the preview module."""
+    main_src = (INFRA_DIR / "__main__.py").read_text()
+    assert "preview" in main_src.lower(), (
+        "__main__.py must import the preview module"
+    )

--- a/tests/test_preview_infra.py
+++ b/tests/test_preview_infra.py
@@ -32,25 +32,19 @@ def test_preview_imports_pulumi_aws():
 def test_defines_preview_environment():
     """preview.py must define PreviewEnvironment class or function."""
     src = _preview_source()
-    assert "PreviewEnvironment" in src, (
-        "preview.py must define PreviewEnvironment"
-    )
+    assert "PreviewEnvironment" in src, "preview.py must define PreviewEnvironment"
 
 
 def test_defines_ecs_service():
     """preview.py must define an ECS Service resource."""
     src = _preview_source()
-    assert "ecs.Service(" in src or "aws.ecs.Service(" in src, (
-        "preview.py must define an ECS Service"
-    )
+    assert "ecs.Service(" in src or "aws.ecs.Service(" in src, "preview.py must define an ECS Service"
 
 
 def test_defines_security_group():
     """preview.py must define a Security Group for inbound traffic."""
     src = _preview_source()
-    assert "SecurityGroup(" in src, (
-        "preview.py must define a SecurityGroup"
-    )
+    assert "SecurityGroup(" in src, "preview.py must define a SecurityGroup"
 
 
 def test_security_group_allows_port_8080():
@@ -74,9 +68,7 @@ def test_desired_count_is_one():
 def test_parameterized_by_pr_number():
     """PreviewEnvironment must accept a PR number parameter."""
     src = _preview_source()
-    assert "pr_number" in src, (
-        "PreviewEnvironment must be parameterized by pr_number"
-    )
+    assert "pr_number" in src, "PreviewEnvironment must be parameterized by pr_number"
 
 
 def test_exports_service_url():
@@ -89,6 +81,4 @@ def test_exports_service_url():
 def test_main_imports_preview_module():
     """__main__.py must import the preview module."""
     main_src = (INFRA_DIR / "__main__.py").read_text()
-    assert "preview" in main_src.lower(), (
-        "__main__.py must import the preview module"
-    )
+    assert "preview" in main_src.lower(), "__main__.py must import the preview module"


### PR DESCRIPTION
## Summary
- Add `infra/preview.py` with `PreviewEnvironment` class for PR-specific ECS Fargate services (FARGATE_SPOT, desired_count=1, inbound 8080)
- Update `infra/__main__.py` to import the preview module
- Add 11 source-level tests in `tests/test_preview_infra.py`

Refs #73