### PR TITLE
feat: ✨ add S3 + CloudFront preview environment

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -4,6 +4,7 @@ import secrets  # noqa: F401 — GitHub Secrets & Environments
 
 import cleanup  # noqa: F401 — PR cleanup Lambda resources
 import ecs  # noqa: F401 — ECS Fargate resources
+import frontend_preview  # noqa: F401 — S3 + CloudFront frontend preview
 import github_app  # noqa: F401 — GitHub App registration
 import preview  # noqa: F401 — ECS Fargate preview environments
 import pulumi

--- a/infra/frontend_preview.py
+++ b/infra/frontend_preview.py
@@ -1,0 +1,133 @@
+"""S3 + CloudFront frontend preview environment for PR-specific deployments (#72).
+
+Creates an S3 bucket and CloudFront distribution per pull request, allowing
+frontend preview before merge.  Uses Origin Access Control (OAC) for secure
+S3 access.
+"""
+
+import pulumi
+import pulumi_aws as aws
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+config = pulumi.Config("frontend_preview")
+pr_number = config.get_int("pr_number") or 0
+
+
+# ---------------------------------------------------------------------------
+# FrontendPreviewEnvironment
+# ---------------------------------------------------------------------------
+class FrontendPreviewEnvironment:
+    """PR-specific S3 + CloudFront frontend preview.
+
+    Parameters
+    ----------
+    pr_number:
+        Pull-request number used to name and tag resources.
+    """
+
+    def __init__(self, pr_number: int) -> None:
+        name = f"myxo-fe-preview-pr-{pr_number}"
+
+        # --- S3 Bucket --------------------------------------------------------
+        self.bucket = aws.s3.BucketV2(
+            f"{name}-bucket",
+            bucket=name,
+            tags={"Name": name, "PR": str(pr_number)},
+        )
+
+        # Block all public access — CloudFront uses OAC
+        aws.s3.BucketPublicAccessBlock(
+            f"{name}-public-access-block",
+            bucket=self.bucket.id,
+            block_public_acls=True,
+            block_public_policy=True,
+            ignore_public_acls=True,
+            restrict_public_buckets=True,
+        )
+
+        # --- Origin Access Control (OAC) -------------------------------------
+        self.oac = aws.cloudfront.OriginAccessControl(
+            f"{name}-oac",
+            name=name,
+            origin_access_control_origin_type="s3",
+            signing_behavior="always",
+            signing_protocol="sigv4",
+        )
+
+        # --- CloudFront Distribution -----------------------------------------
+        self.distribution = aws.cloudfront.Distribution(
+            f"{name}-cdn",
+            enabled=True,
+            default_root_object="index.html",
+            origins=[
+                aws.cloudfront.DistributionOriginArgs(
+                    domain_name=self.bucket.bucket_regional_domain_name,
+                    origin_id=f"s3-{name}",
+                    origin_access_control_id=self.oac.id,
+                ),
+            ],
+            default_cache_behavior=aws.cloudfront.DistributionDefaultCacheBehaviorArgs(
+                allowed_methods=["GET", "HEAD"],
+                cached_methods=["GET", "HEAD"],
+                target_origin_id=f"s3-{name}",
+                viewer_protocol_policy="redirect-to-https",
+                forwarded_values=aws.cloudfront.DistributionDefaultCacheBehaviorForwardedValuesArgs(
+                    query_string=False,
+                    cookies=aws.cloudfront.DistributionDefaultCacheBehaviorForwardedValuesCookiesArgs(
+                        forward="none",
+                    ),
+                ),
+            ),
+            restrictions=aws.cloudfront.DistributionRestrictionsArgs(
+                geo_restriction=aws.cloudfront.DistributionRestrictionsGeoRestrictionArgs(
+                    restriction_type="none",
+                ),
+            ),
+            viewer_certificate=aws.cloudfront.DistributionViewerCertificateArgs(
+                cloudfront_default_certificate=True,
+            ),
+            comment=f"Frontend preview for PR #{pr_number}",
+            tags={"Name": name, "PR": str(pr_number)},
+        )
+
+        # --- S3 Bucket Policy (allow CloudFront OAC) -------------------------
+        aws.s3.BucketPolicy(
+            f"{name}-bucket-policy",
+            bucket=self.bucket.id,
+            policy=pulumi.Output.all(self.bucket.arn, self.distribution.arn).apply(
+                lambda args: (
+                    f"""{{
+  "Version": "2012-10-17",
+  "Statement": [
+    {{
+      "Sid": "AllowCloudFrontServicePrincipal",
+      "Effect": "Allow",
+      "Principal": {{
+        "Service": "cloudfront.amazonaws.com"
+      }},
+      "Action": "s3:GetObject",
+      "Resource": "{args[0]}/*",
+      "Condition": {{
+        "StringEquals": {{
+          "AWS:SourceArn": "{args[1]}"
+        }}
+      }}
+    }}
+  ]
+}}"""
+                )
+            ),
+        )
+
+        self.domain_name = self.distribution.domain_name
+
+
+# ---------------------------------------------------------------------------
+# Instantiate only when a PR number is provided via config
+# ---------------------------------------------------------------------------
+if pr_number:
+    preview = FrontendPreviewEnvironment(pr_number)
+
+    pulumi.export("frontend_preview_domain", preview.domain_name)

--- a/tests/test_frontend_preview_infra.py
+++ b/tests/test_frontend_preview_infra.py
@@ -1,0 +1,62 @@
+"""S3 + CloudFront frontend preview environment infrastructure tests.
+
+Validates that the frontend preview Pulumi module defines the expected
+resources for PR-specific static frontend hosting (#72).
+"""
+
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+
+
+def test_frontend_preview_module_exists():
+    """infra/frontend_preview.py must exist."""
+    assert (INFRA_DIR / "frontend_preview.py").is_file(), "infra/frontend_preview.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Resource definitions in frontend_preview.py
+# ---------------------------------------------------------------------------
+
+
+def _frontend_preview_source() -> str:
+    return (INFRA_DIR / "frontend_preview.py").read_text()
+
+
+def test_frontend_preview_imports_pulumi_aws():
+    """frontend_preview.py must import pulumi_aws."""
+    src = _frontend_preview_source()
+    assert "pulumi_aws" in src, "frontend_preview.py must import pulumi_aws"
+
+
+def test_defines_s3_bucket():
+    """frontend_preview.py must define an S3 Bucket resource."""
+    src = _frontend_preview_source()
+    assert "aws.s3.BucketV2(" in src or "s3.BucketV2(" in src, "frontend_preview.py must define an S3 BucketV2"
+
+
+def test_defines_cloudfront_distribution():
+    """frontend_preview.py must define a CloudFront Distribution resource."""
+    src = _frontend_preview_source()
+    assert "cloudfront.Distribution(" in src or "aws.cloudfront.Distribution(" in src, (
+        "frontend_preview.py must define a CloudFront Distribution"
+    )
+
+
+def test_parameterized_by_pr_number():
+    """FrontendPreviewEnvironment must accept a PR number parameter."""
+    src = _frontend_preview_source()
+    assert "pr_number" in src, "FrontendPreviewEnvironment must be parameterized by pr_number"
+
+
+def test_exports_cloudfront_domain():
+    """frontend_preview.py must export the CloudFront domain name."""
+    src = _frontend_preview_source()
+    assert "pulumi.export(" in src, "frontend_preview.py must export a value"
+    assert "domain" in src.lower(), "frontend_preview.py must export a CloudFront domain"
+
+
+def test_main_imports_frontend_preview_module():
+    """__main__.py must import the frontend_preview module."""
+    main_src = (INFRA_DIR / "__main__.py").read_text()
+    assert "frontend_preview" in main_src, "__main__.py must import the frontend_preview module"


### PR DESCRIPTION
## Summary
- Add `infra/frontend_preview.py` Pulumi module: S3 bucket + CloudFront distribution (OAC) for PR-specific frontend preview hosting
- Parameterized by PR number; exports CloudFront domain name
- Integrate module import in `infra/__main__.py`

Refs #72