### PR TITLE
feat: ✨ add Infisical server infrastructure

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -5,6 +5,7 @@ import secrets  # noqa: F401 — GitHub Secrets & Environments
 import cleanup  # noqa: F401 — PR cleanup Lambda resources
 import ecs  # noqa: F401 — ECS Fargate resources
 import github_app  # noqa: F401 — GitHub App registration
+import infisical  # noqa: F401 — Infisical secrets manager
 import preview  # noqa: F401 — ECS Fargate preview environments
 import pulumi
 import pulumi_github as github

--- a/infra/infisical.py
+++ b/infra/infisical.py
@@ -1,0 +1,153 @@
+"""Infisical server infrastructure (self-hosted on ECS Fargate).
+
+Defines an ECS Fargate service running the Infisical secrets manager.
+Uses the existing ECS cluster from ecs.py.  Actual secret values
+(MONGO_URL, ENCRYPTION_KEY, etc.) come from Pulumi config, never hardcoded.
+
+Ref: https://infisical.com/docs/self-hosting/deployments/aws
+"""
+
+import json
+
+import ecs as ecs_infra
+import pulumi
+import pulumi_aws as aws
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+config = pulumi.Config("infisical")
+
+# Sensitive values from Pulumi encrypted config
+mongo_url = config.require_secret("MONGO_URL")
+encryption_key = config.require_secret("ENCRYPTION_KEY")
+auth_secret = config.require_secret("AUTH_SECRET")
+site_url = config.get("SITE_URL") or "https://infisical.internal"
+
+_COST_TAGS = {
+    "Project": "myxo-lab",
+    "Environment": pulumi.get_stack(),
+    "CostCenter": "secrets-management",
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch Log Group
+# ---------------------------------------------------------------------------
+log_group = aws.cloudwatch.LogGroup(
+    "infisical-log-group",
+    name="/ecs/infisical",
+    retention_in_days=14,
+    tags=_COST_TAGS,
+)
+
+# ---------------------------------------------------------------------------
+# Security Group — allow inbound 443 (HTTPS)
+# ---------------------------------------------------------------------------
+infisical_sg = aws.ec2.SecurityGroup(
+    "infisical-sg",
+    name="infisical-sg",
+    description="Allow inbound HTTPS traffic to Infisical",
+    ingress=[
+        aws.ec2.SecurityGroupIngressArgs(
+            protocol="tcp",
+            from_port=443,
+            to_port=443,
+            cidr_blocks=["0.0.0.0/0"],
+            description="HTTPS inbound",
+        ),
+    ],
+    egress=[
+        aws.ec2.SecurityGroupEgressArgs(
+            protocol="-1",
+            from_port=0,
+            to_port=0,
+            cidr_blocks=["0.0.0.0/0"],
+            description="Allow all outbound",
+        ),
+    ],
+    tags={"Name": "infisical-sg", **_COST_TAGS},
+)
+
+# ---------------------------------------------------------------------------
+# ECS Task Definition
+# ---------------------------------------------------------------------------
+aws_config = pulumi.Config("aws")
+_region = aws_config.require("region")
+
+container_definitions = pulumi.Output.all(
+    log_group.name,
+    mongo_url,
+    encryption_key,
+    auth_secret,
+).apply(
+    lambda args: json.dumps(
+        [
+            {
+                "name": "infisical",
+                "image": "infisical/infisical:latest",
+                "cpu": 512,
+                "memory": 1024,
+                "essential": True,
+                "portMappings": [
+                    {
+                        "containerPort": 443,
+                        "protocol": "tcp",
+                    }
+                ],
+                "environment": [
+                    {"name": "MONGO_URL", "value": args[1]},
+                    {"name": "ENCRYPTION_KEY", "value": args[2]},
+                    {"name": "AUTH_SECRET", "value": args[3]},
+                    {"name": "SITE_URL", "value": site_url},
+                    {"name": "NODE_ENV", "value": "production"},
+                ],
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": args[0],
+                        "awslogs-region": _region,
+                        "awslogs-stream-prefix": "infisical",
+                    },
+                },
+            }
+        ]
+    )
+)
+
+task_definition = aws.ecs.TaskDefinition(
+    "infisical-task",
+    family="infisical-task",
+    cpu="512",
+    memory="1024",
+    network_mode="awsvpc",
+    requires_compatibilities=["FARGATE"],
+    execution_role_arn=ecs_infra.task_execution_role.arn,
+    task_role_arn=ecs_infra.task_role.arn,
+    container_definitions=container_definitions,
+    tags=_COST_TAGS,
+)
+
+# ---------------------------------------------------------------------------
+# ECS Service
+# ---------------------------------------------------------------------------
+infisical_service = aws.ecs.Service(
+    "infisical-service",
+    name="infisical-service",
+    cluster=ecs_infra.cluster.arn,
+    task_definition=task_definition.arn,
+    desired_count=1,
+    launch_type="FARGATE",
+    network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
+        assign_public_ip=False,
+        security_groups=[infisical_sg.id],
+        # TODO(#86): Add subnet IDs once VPC resources are available
+        subnets=[],
+    ),
+    tags=_COST_TAGS,
+)
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+pulumi.export("infisical_service_name", infisical_service.name)
+pulumi.export("infisical_task_definition_arn", task_definition.arn)

--- a/tests/test_infisical_infra.py
+++ b/tests/test_infisical_infra.py
@@ -1,0 +1,106 @@
+"""Tests for Infisical server infrastructure module.
+
+Validates that infra/infisical.py defines an ECS Fargate service
+for self-hosted Infisical with the expected resource definitions.
+"""
+
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+INFISICAL_MODULE = INFRA_DIR / "infisical.py"
+MAIN_MODULE = INFRA_DIR / "__main__.py"
+
+
+def _infisical_source() -> str:
+    return INFISICAL_MODULE.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Module existence
+# ---------------------------------------------------------------------------
+
+
+def test_infisical_module_exists():
+    """infra/infisical.py must exist."""
+    assert INFISICAL_MODULE.is_file(), "infra/infisical.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Imports
+# ---------------------------------------------------------------------------
+
+
+def test_infisical_imports_pulumi_aws():
+    """infisical.py must import pulumi_aws."""
+    src = _infisical_source()
+    assert "import pulumi_aws" in src, "infisical.py must import pulumi_aws"
+
+
+# ---------------------------------------------------------------------------
+# ECS resources
+# ---------------------------------------------------------------------------
+
+
+def test_defines_ecs_service_or_task_definition():
+    """infisical.py must define an ECS Service or TaskDefinition for Infisical."""
+    src = _infisical_source()
+    has_service = "ecs.Service(" in src
+    has_task_def = "ecs.TaskDefinition(" in src
+    assert has_service or has_task_def, "infisical.py must define ecs.Service or ecs.TaskDefinition"
+
+
+def test_defines_task_definition():
+    """infisical.py must define an ECS TaskDefinition."""
+    src = _infisical_source()
+    assert "ecs.TaskDefinition(" in src, "infisical.py must define ecs.TaskDefinition for Infisical"
+
+
+def test_defines_ecs_service():
+    """infisical.py must define an ECS Service."""
+    src = _infisical_source()
+    assert "ecs.Service(" in src, "infisical.py must define ecs.Service for Infisical"
+
+
+# ---------------------------------------------------------------------------
+# Security group
+# ---------------------------------------------------------------------------
+
+
+def test_defines_security_group():
+    """infisical.py must define a Security Group allowing inbound 443."""
+    src = _infisical_source()
+    assert "SecurityGroup(" in src, "infisical.py must define a SecurityGroup"
+    assert "443" in src, "Security group must allow inbound port 443"
+
+
+# ---------------------------------------------------------------------------
+# Infisical naming
+# ---------------------------------------------------------------------------
+
+
+def test_infisical_naming():
+    """Key resources must include 'infisical' in their names."""
+    src = _infisical_source()
+    assert "infisical" in src.lower(), "Resources must reference infisical"
+
+
+# ---------------------------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------------------------
+
+
+def test_contains_mongo_url_env_var():
+    """Container definition must reference MONGO_URL environment variable."""
+    src = _infisical_source()
+    assert "MONGO_URL" in src, "Container definition must include MONGO_URL environment variable"
+
+
+# ---------------------------------------------------------------------------
+# __main__.py integration
+# ---------------------------------------------------------------------------
+
+
+def test_main_imports_infisical():
+    """__main__.py must import the infisical module."""
+    content = MAIN_MODULE.read_text()
+    assert "import infisical" in content, "__main__.py must import infisical module"


### PR DESCRIPTION
## Summary
- Add infra/infisical.py — ECS Fargate service for self-hosted Infisical secrets manager
- Define security group allowing inbound HTTPS (port 443)
- Configure container with MONGO_URL, ENCRYPTION_KEY, AUTH_SECRET environment variables from Pulumi config
- Add CloudWatch log group and reuse existing ECS cluster/IAM roles from ecs.py
- Register module in infra/__main__.py

Refs #86