### PR TITLE
fix: 🔒️ harden S3 + CloudFront preview environment

### DIFF
--- a/infra/frontend_preview.py
+++ b/infra/frontend_preview.py
@@ -5,6 +5,8 @@ frontend preview before merge.  Uses Origin Access Control (OAC) for secure
 S3 access.
 """
 
+import json
+
 import pulumi
 import pulumi_aws as aws
 
@@ -28,13 +30,28 @@ class FrontendPreviewEnvironment:
     """
 
     def __init__(self, pr_number: int) -> None:
-        name = f"myxo-fe-preview-pr-{pr_number}"
+        stack = pulumi.get_stack()
+        name = f"myxo-fe-preview-{stack}-pr-{pr_number}"
 
         # --- S3 Bucket --------------------------------------------------------
         self.bucket = aws.s3.BucketV2(
             f"{name}-bucket",
             bucket=name,
+            force_destroy=True,
             tags={"Name": name, "PR": str(pr_number)},
+        )
+
+        # --- S3 Default Encryption (SSE-S3) -----------------------------------
+        aws.s3.BucketServerSideEncryptionConfigurationV2(
+            f"{name}-encryption",
+            bucket=self.bucket.id,
+            rules=[
+                aws.s3.BucketServerSideEncryptionConfigurationV2RuleArgs(
+                    apply_server_side_encryption_by_default=aws.s3.BucketServerSideEncryptionConfigurationV2RuleApplyServerSideEncryptionByDefaultArgs(
+                        sse_algorithm="AES256",
+                    ),
+                ),
+            ],
         )
 
         # Block all public access — CloudFront uses OAC
@@ -88,6 +105,7 @@ class FrontendPreviewEnvironment:
             viewer_certificate=aws.cloudfront.DistributionViewerCertificateArgs(
                 cloudfront_default_certificate=True,
             ),
+            price_class="PriceClass_100",
             comment=f"Frontend preview for PR #{pr_number}",
             tags={"Name": name, "PR": str(pr_number)},
         )
@@ -97,26 +115,24 @@ class FrontendPreviewEnvironment:
             f"{name}-bucket-policy",
             bucket=self.bucket.id,
             policy=pulumi.Output.all(self.bucket.arn, self.distribution.arn).apply(
-                lambda args: (
-                    f"""{{
-  "Version": "2012-10-17",
-  "Statement": [
-    {{
-      "Sid": "AllowCloudFrontServicePrincipal",
-      "Effect": "Allow",
-      "Principal": {{
-        "Service": "cloudfront.amazonaws.com"
-      }},
-      "Action": "s3:GetObject",
-      "Resource": "{args[0]}/*",
-      "Condition": {{
-        "StringEquals": {{
-          "AWS:SourceArn": "{args[1]}"
-        }}
-      }}
-    }}
-  ]
-}}"""
+                lambda args: json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Sid": "AllowCloudFrontServicePrincipal",
+                                "Effect": "Allow",
+                                "Principal": {"Service": "cloudfront.amazonaws.com"},
+                                "Action": "s3:GetObject",
+                                "Resource": f"{args[0]}/*",
+                                "Condition": {
+                                    "StringEquals": {
+                                        "AWS:SourceArn": args[1],
+                                    }
+                                },
+                            }
+                        ],
+                    }
                 )
             ),
         )
@@ -130,4 +146,5 @@ class FrontendPreviewEnvironment:
 if pr_number:
     preview = FrontendPreviewEnvironment(pr_number)
 
-    pulumi.export("frontend_preview_domain", preview.domain_name)
+    pulumi.export("frontend_preview_bucket_name", preview.bucket.bucket)
+    pulumi.export("frontend_preview_cdn_domain", preview.domain_name)

--- a/infra/frontend_preview.py
+++ b/infra/frontend_preview.py
@@ -30,7 +30,7 @@ class FrontendPreviewEnvironment:
     """
 
     def __init__(self, pr_number: int) -> None:
-        stack = pulumi.get_stack()
+        stack = pulumi.get_stack().lower().replace("_", "-")
         name = f"myxo-fe-preview-{stack}-pr-{pr_number}"
 
         # --- S3 Bucket --------------------------------------------------------
@@ -114,7 +114,11 @@ class FrontendPreviewEnvironment:
         aws.s3.BucketPolicy(
             f"{name}-bucket-policy",
             bucket=self.bucket.id,
-            policy=pulumi.Output.all(self.bucket.arn, self.distribution.arn).apply(
+            policy=pulumi.Output.all(
+                self.bucket.arn,
+                self.distribution.arn,
+                aws.get_caller_identity().account_id,
+            ).apply(
                 lambda args: json.dumps(
                     {
                         "Version": "2012-10-17",
@@ -128,6 +132,7 @@ class FrontendPreviewEnvironment:
                                 "Condition": {
                                     "StringEquals": {
                                         "AWS:SourceArn": args[1],
+                                        "AWS:SourceAccount": args[2],
                                     }
                                 },
                             }

--- a/tests/test_frontend_preview_infra.py
+++ b/tests/test_frontend_preview_infra.py
@@ -60,3 +60,72 @@ def test_main_imports_frontend_preview_module():
     """__main__.py must import the frontend_preview module."""
     main_src = (INFRA_DIR / "__main__.py").read_text()
     assert "frontend_preview" in main_src, "__main__.py must import the frontend_preview module"
+
+
+# ---------------------------------------------------------------------------
+# S3 + CloudFront hardening tests (#241)
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_policy_uses_json_dumps():
+    """Bucket policy must be built with json.dumps, not f-string."""
+    src = _frontend_preview_source()
+    assert "import json" in src or "from json import" in src, "frontend_preview.py must import json"
+    assert "json.dumps(" in src, "Bucket policy must use json.dumps instead of f-string"
+
+
+def test_bucket_name_includes_stack():
+    """S3 bucket name must include pulumi.get_stack() to avoid collisions."""
+    src = _frontend_preview_source()
+    assert "pulumi.get_stack()" in src, "Bucket name must include pulumi.get_stack() for collision avoidance"
+
+
+def test_bucket_force_destroy():
+    """S3 bucket must set force_destroy=True for easy cleanup."""
+    src = _frontend_preview_source()
+    assert "force_destroy=True" in src, "S3 bucket must have force_destroy=True"
+
+
+def test_bucket_default_encryption():
+    """S3 bucket must have default encryption (SSE-S3) configured."""
+    src = _frontend_preview_source()
+    assert "BucketServerSideEncryptionConfigurationV2(" in src or ("ServerSideEncryptionConfiguration(" in src), (
+        "S3 bucket must have default encryption configured"
+    )
+    assert "aws:s3" in src or "AES256" in src, "S3 bucket encryption must use SSE-S3 (AES256)"
+
+
+def test_cloudfront_price_class_100():
+    """CloudFront distribution must use PriceClass_100 for cost savings."""
+    src = _frontend_preview_source()
+    assert "PriceClass_100" in src, "CloudFront distribution must set price_class to PriceClass_100"
+
+
+def test_bucket_public_access_block_defined():
+    """BucketPublicAccessBlock must block all public access."""
+    src = _frontend_preview_source()
+    assert "BucketPublicAccessBlock(" in src, "frontend_preview.py must define BucketPublicAccessBlock"
+    assert "block_public_acls=True" in src, "Must block public ACLs"
+    assert "block_public_policy=True" in src, "Must block public policy"
+    assert "ignore_public_acls=True" in src, "Must ignore public ACLs"
+    assert "restrict_public_buckets=True" in src, "Must restrict public buckets"
+
+
+def test_origin_access_control_defined():
+    """OriginAccessControl must be defined with correct settings."""
+    src = _frontend_preview_source()
+    assert "OriginAccessControl(" in src, "frontend_preview.py must define OriginAccessControl"
+    assert 'signing_behavior="always"' in src, "OAC must sign always"
+    assert 'signing_protocol="sigv4"' in src, "OAC must use sigv4"
+
+
+def test_export_keys_strict():
+    """Export keys must follow strict naming conventions."""
+    src = _frontend_preview_source()
+    # Must export bucket_name and cdn_domain with exact keys
+    assert '"frontend_preview_bucket_name"' in src or "'frontend_preview_bucket_name'" in src, (
+        "Must export 'frontend_preview_bucket_name'"
+    )
+    assert '"frontend_preview_cdn_domain"' in src or "'frontend_preview_cdn_domain'" in src, (
+        "Must export 'frontend_preview_cdn_domain'"
+    )


### PR DESCRIPTION
## Summary
- Build bucket policy with `json.dumps` instead of f-string for safe JSON generation
- Include `pulumi.get_stack()` in S3 bucket name to avoid cross-stack naming collisions
- Add `force_destroy=True` and default encryption (SSE-S3 / AES256)
- Set CloudFront `price_class` to `PriceClass_100` for cost reduction
- Add `AWS:SourceAccount` condition to bucket policy for confused-deputy mitigation
- Strengthen tests for `BucketPublicAccessBlock`, `OriginAccessControl`, and export keys

Closes #241