### PR TITLE
feat: ✨ add Infisical dynamic key retrieval config

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -7,6 +7,7 @@ import ecs
 import frontend_preview
 import github_app
 import infisical
+import infisical_client
 import preview
 import pulumi
 import pulumi_github as github
@@ -19,6 +20,7 @@ __all__ = [
     "frontend_preview",
     "github_app",
     "infisical",
+    "infisical_client",
     "preview",
     "secrets",
     "stale_cleanup",

--- a/infra/infisical_client.py
+++ b/infra/infisical_client.py
@@ -1,0 +1,88 @@
+"""Infisical client configuration for dynamic secret retrieval.
+
+Defines the mapping of secrets that should be retrieved from Infisical
+instead of GitHub Actions secrets, along with project and environment
+configuration for the Infisical SDK integration.
+
+Ref: #87 — Migrate to dynamic API key retrieval via Infisical
+"""
+
+import pulumi
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+config = pulumi.Config("infisical")
+stack = pulumi.get_stack()
+
+# Infisical project identifier (from Pulumi encrypted config)
+infisical_project_id = config.require_secret("PROJECT_ID")
+
+# Infisical client credentials for SDK authentication
+infisical_client_id = config.require_secret("CLIENT_ID")
+infisical_client_secret = config.require_secret("CLIENT_SECRET")
+
+# ---------------------------------------------------------------------------
+# Environment mapping — Pulumi stack → Infisical environment slug
+# ---------------------------------------------------------------------------
+ENVIRONMENT_MAP: dict[str, str] = {
+    "dev": "dev",
+    "staging": "staging",
+    "prod": "prod",
+}
+
+infisical_environment = ENVIRONMENT_MAP.get(stack, "dev")
+
+# ---------------------------------------------------------------------------
+# Secret mapping — migration path from GitHub Secrets to Infisical
+#
+# Each entry defines:
+#   - source: where the secret currently lives
+#       "infisical"       → retrieve dynamically via Infisical SDK
+#       "github_secrets"  → keep in GitHub Actions secrets (Pulumi-managed)
+#   - path: Infisical secret path (only for source="infisical")
+# ---------------------------------------------------------------------------
+SECRET_MAPPING: dict[str, dict[str, str]] = {
+    # Phase 1: Migrate API keys to Infisical (dynamic retrieval)
+    "ANTHROPIC_API_KEY_MYXO": {
+        "source": "infisical",
+        "path": "/api-keys/anthropic-myxo",
+    },
+    "ANTHROPIC_API_KEY_SCHEDULED": {
+        "source": "infisical",
+        "path": "/api-keys/anthropic-scheduled",
+    },
+    # Phase 2: Keep infrastructure credentials in GitHub Secrets for now
+    "AWS_ACCESS_KEY_ID": {
+        "source": "github_secrets",
+        "path": "",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "source": "github_secrets",
+        "path": "",
+    },
+    "PULUMI_ACCESS_TOKEN": {
+        "source": "github_secrets",
+        "path": "",
+    },
+    # GitHub App credentials — keep in GitHub Secrets
+    "GITHUB_APP_PRIVATE_KEY": {
+        "source": "github_secrets",
+        "path": "",
+    },
+    "MYXO_APP_ID": {
+        "source": "github_secrets",
+        "path": "",
+    },
+}
+
+# Derived lists for convenience
+INFISICAL_SECRETS = [k for k, v in SECRET_MAPPING.items() if v["source"] == "infisical"]
+GITHUB_SECRETS = [k for k, v in SECRET_MAPPING.items() if v["source"] == "github_secrets"]
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+pulumi.export("infisical_environment", infisical_environment)
+pulumi.export("infisical_secret_count", len(INFISICAL_SECRETS))
+pulumi.export("github_secret_count", len(GITHUB_SECRETS))

--- a/infra/infisical_client.py
+++ b/infra/infisical_client.py
@@ -16,21 +16,24 @@ config = pulumi.Config("infisical")
 stack = pulumi.get_stack()
 
 # Infisical project identifier (from Pulumi encrypted config)
-infisical_project_id = config.require_secret("PROJECT_ID")
-
-# Infisical client credentials for SDK authentication
-infisical_client_id = config.require_secret("CLIENT_ID")
-infisical_client_secret = config.require_secret("CLIENT_SECRET")
+# Using get_secret to avoid requiring config before Infisical is fully set up
+infisical_project_id = config.get_secret("PROJECT_ID")
+infisical_client_id = config.get_secret("CLIENT_ID")
+infisical_client_secret = config.get_secret("CLIENT_SECRET")
 
 # ---------------------------------------------------------------------------
 # Environment mapping — Pulumi stack → Infisical environment slug
 # ---------------------------------------------------------------------------
 ENVIRONMENT_MAP: dict[str, str] = {
     "dev": "dev",
+    "development": "dev",
     "staging": "staging",
     "prod": "prod",
+    "production": "prod",
 }
 
+if stack not in ENVIRONMENT_MAP:
+    pulumi.log.warn(f"Unknown stack '{stack}' — defaulting Infisical environment to 'dev'")
 infisical_environment = ENVIRONMENT_MAP.get(stack, "dev")
 
 # ---------------------------------------------------------------------------
@@ -40,9 +43,9 @@ infisical_environment = ENVIRONMENT_MAP.get(stack, "dev")
 #   - source: where the secret currently lives
 #       "infisical"       → retrieve dynamically via Infisical SDK
 #       "github_secrets"  → keep in GitHub Actions secrets (Pulumi-managed)
-#   - path: Infisical secret path (only for source="infisical")
+#   - path: Infisical secret path (required for source="infisical")
 # ---------------------------------------------------------------------------
-SECRET_MAPPING: dict[str, dict[str, str]] = {
+SECRET_MAPPING: dict[str, dict[str, str | None]] = {
     # Phase 1: Migrate API keys to Infisical (dynamic retrieval)
     "ANTHROPIC_API_KEY_MYXO": {
         "source": "infisical",
@@ -53,27 +56,12 @@ SECRET_MAPPING: dict[str, dict[str, str]] = {
         "path": "/api-keys/anthropic-scheduled",
     },
     # Phase 2: Keep infrastructure credentials in GitHub Secrets for now
-    "AWS_ACCESS_KEY_ID": {
-        "source": "github_secrets",
-        "path": "",
-    },
-    "AWS_SECRET_ACCESS_KEY": {
-        "source": "github_secrets",
-        "path": "",
-    },
-    "PULUMI_ACCESS_TOKEN": {
-        "source": "github_secrets",
-        "path": "",
-    },
+    "AWS_ACCESS_KEY_ID": {"source": "github_secrets", "path": None},
+    "AWS_SECRET_ACCESS_KEY": {"source": "github_secrets", "path": None},
+    "PULUMI_ACCESS_TOKEN": {"source": "github_secrets", "path": None},
     # GitHub App credentials — keep in GitHub Secrets
-    "GITHUB_APP_PRIVATE_KEY": {
-        "source": "github_secrets",
-        "path": "",
-    },
-    "MYXO_APP_ID": {
-        "source": "github_secrets",
-        "path": "",
-    },
+    "GITHUB_APP_PRIVATE_KEY": {"source": "github_secrets", "path": None},
+    "MYXO_APP_ID": {"source": "github_secrets", "path": None},
 }
 
 # Derived lists for convenience

--- a/tests/test_infisical_client.py
+++ b/tests/test_infisical_client.py
@@ -1,0 +1,139 @@
+"""Tests for Infisical client configuration module.
+
+Validates that infra/infisical_client.py defines the configuration layer
+for dynamic secret retrieval via the Infisical SDK, replacing hardcoded
+GitHub Actions secrets.
+
+Ref: #87
+"""
+
+import re
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+CLIENT_MODULE = INFRA_DIR / "infisical_client.py"
+MAIN_MODULE = INFRA_DIR / "__main__.py"
+
+
+def _client_source() -> str:
+    return CLIENT_MODULE.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Module existence
+# ---------------------------------------------------------------------------
+
+
+def test_infisical_client_module_exists():
+    """infra/infisical_client.py must exist."""
+    assert CLIENT_MODULE.is_file(), "infra/infisical_client.py must exist"
+
+
+# ---------------------------------------------------------------------------
+# Imports
+# ---------------------------------------------------------------------------
+
+
+def test_imports_pulumi():
+    """infisical_client.py must import pulumi for config/exports."""
+    src = _client_source()
+    assert "import pulumi" in src, "infisical_client.py must import pulumi"
+
+
+# ---------------------------------------------------------------------------
+# Secret mapping / migration config
+# ---------------------------------------------------------------------------
+
+
+def test_defines_secret_mapping():
+    """infisical_client.py must define a mapping of secrets for migration."""
+    src = _client_source()
+    has_mapping = "INFISICAL_SECRETS" in src or "SECRET_MAPPING" in src
+    assert has_mapping, "infisical_client.py must define INFISICAL_SECRETS or SECRET_MAPPING"
+
+
+def test_secret_mapping_includes_anthropic_keys():
+    """Secret mapping must include Anthropic API keys for dynamic retrieval."""
+    src = _client_source()
+    assert "ANTHROPIC_API_KEY_MYXO" in src, "Secret mapping must include ANTHROPIC_API_KEY_MYXO"
+    assert "ANTHROPIC_API_KEY_SCHEDULED" in src, "Secret mapping must include ANTHROPIC_API_KEY_SCHEDULED"
+
+
+def test_secret_mapping_categorizes_sources():
+    """Secret mapping must indicate source (infisical vs github_secrets)."""
+    src = _client_source()
+    has_source = "infisical" in src.lower() and (
+        "github_secrets" in src or "github-secrets" in src or "GITHUB_SECRETS" in src
+    )
+    assert has_source, "Secret mapping must categorize secrets by source (infisical vs github_secrets)"
+
+
+# ---------------------------------------------------------------------------
+# Infisical project / environment references
+# ---------------------------------------------------------------------------
+
+
+def test_references_infisical_project():
+    """infisical_client.py must reference an Infisical project identifier."""
+    src = _client_source()
+    has_project = "project" in src.lower() or "INFISICAL_PROJECT" in src or "project_id" in src
+    assert has_project, "infisical_client.py must reference Infisical project configuration"
+
+
+def test_references_infisical_environment():
+    """infisical_client.py must reference Infisical environment (dev/staging/prod)."""
+    src = _client_source()
+    has_env = "environment" in src.lower()
+    assert has_env, "infisical_client.py must reference Infisical environment"
+
+
+def test_environment_values():
+    """infisical_client.py must define dev/staging/prod environments."""
+    src = _client_source()
+    for env in ("dev", "staging", "prod"):
+        assert env in src.lower(), f"infisical_client.py must reference '{env}' environment"
+
+
+# ---------------------------------------------------------------------------
+# Security: no hardcoded secrets
+# ---------------------------------------------------------------------------
+
+
+def test_no_hardcoded_secret_values():
+    """infisical_client.py must not contain hardcoded secret values."""
+    src = _client_source()
+    suspicious = re.findall(r'["\'][A-Za-z0-9+/]{32,}["\']', src)
+    assert len(suspicious) == 0, f"infisical_client.py may contain hardcoded secret values: {suspicious}"
+
+
+# ---------------------------------------------------------------------------
+# Pulumi config for Infisical client credentials
+# ---------------------------------------------------------------------------
+
+
+def test_uses_pulumi_config():
+    """infisical_client.py must use pulumi.Config for client credentials."""
+    src = _client_source()
+    assert "pulumi.Config" in src, "infisical_client.py must use pulumi.Config for credentials"
+
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
+
+def test_exports_configuration():
+    """infisical_client.py must export configuration via pulumi.export."""
+    src = _client_source()
+    assert "pulumi.export" in src, "infisical_client.py must export configuration"
+
+
+# ---------------------------------------------------------------------------
+# __main__.py integration
+# ---------------------------------------------------------------------------
+
+
+def test_main_imports_infisical_client():
+    """__main__.py must import the infisical_client module."""
+    content = MAIN_MODULE.read_text()
+    assert "infisical_client" in content, "__main__.py must import infisical_client module"

--- a/tests/test_infisical_client.py
+++ b/tests/test_infisical_client.py
@@ -74,17 +74,16 @@ def test_secret_mapping_categorizes_sources():
 
 
 def test_references_infisical_project():
-    """infisical_client.py must reference an Infisical project identifier."""
+    """infisical_client.py must use Pulumi config for project ID."""
     src = _client_source()
-    has_project = "project" in src.lower() or "INFISICAL_PROJECT" in src or "project_id" in src
-    assert has_project, "infisical_client.py must reference Infisical project configuration"
+    assert 'get_secret("PROJECT_ID")' in src, "Must use config.get_secret for PROJECT_ID"
 
 
 def test_references_infisical_environment():
-    """infisical_client.py must reference Infisical environment (dev/staging/prod)."""
+    """infisical_client.py must use ENVIRONMENT_MAP for stack-to-env mapping."""
     src = _client_source()
-    has_env = "environment" in src.lower()
-    assert has_env, "infisical_client.py must reference Infisical environment"
+    assert "ENVIRONMENT_MAP" in src, "Must define ENVIRONMENT_MAP"
+    assert "pulumi.get_stack()" in src, "Must use pulumi.get_stack() for environment selection"
 
 
 def test_environment_values():


### PR DESCRIPTION
## Summary
- Add `infra/infisical_client.py` with `SECRET_MAPPING` that categorizes each secret by source (`infisical` for dynamic SDK retrieval vs `github_secrets` for Pulumi-managed)
- Define Infisical project/environment configuration via `pulumi.Config` (encrypted)
- Phase 1 migrates Anthropic API keys to Infisical; infrastructure credentials remain in GitHub Secrets
- Register module in `infra/__main__.py`

Refs #87