### PR TITLE
fix: 🔒️ harden Infisical server infrastructure

### DIFF
--- a/infra/infisical.py
+++ b/infra/infisical.py
@@ -3,6 +3,7 @@
 Defines an ECS Fargate service running the Infisical secrets manager.
 Uses the existing ECS cluster from ecs.py.  Actual secret values
 (MONGO_URL, ENCRYPTION_KEY, etc.) come from Pulumi config, never hardcoded.
+Secrets are stored in SSM Parameter Store and injected via the ECS secrets field.
 
 Ref: https://infisical.com/docs/self-hosting/deployments/aws
 """
@@ -17,6 +18,7 @@ import pulumi_aws as aws
 # Configuration
 # ---------------------------------------------------------------------------
 config = pulumi.Config("infisical")
+vpc_config = pulumi.Config("vpc")
 
 # Sensitive values from Pulumi encrypted config
 mongo_url = config.require_secret("MONGO_URL")
@@ -24,11 +26,45 @@ encryption_key = config.require_secret("ENCRYPTION_KEY")
 auth_secret = config.require_secret("AUTH_SECRET")
 site_url = config.get("SITE_URL") or "https://infisical.internal"
 
+# Network configuration from Pulumi config
+vpc_id = vpc_config.require("id")
+subnet_ids: list[str] = vpc_config.require_object("private_subnet_ids")
+ingress_cidr_blocks: list[str] = config.get_object("ingress_cidr_blocks") or [
+    vpc_config.require("cidr_block"),
+]
+
 _COST_TAGS = {
     "Project": "myxo-lab",
     "Environment": pulumi.get_stack(),
     "CostCenter": "secrets-management",
 }
+
+# ---------------------------------------------------------------------------
+# SSM Parameter Store — secrets for ECS container
+# ---------------------------------------------------------------------------
+ssm_mongo_url = aws.ssm.Parameter(
+    "infisical-ssm-mongo-url",
+    name="/infisical/MONGO_URL",
+    type="SecureString",
+    value=mongo_url,
+    tags=_COST_TAGS,
+)
+
+ssm_encryption_key = aws.ssm.Parameter(
+    "infisical-ssm-encryption-key",
+    name="/infisical/ENCRYPTION_KEY",
+    type="SecureString",
+    value=encryption_key,
+    tags=_COST_TAGS,
+)
+
+ssm_auth_secret = aws.ssm.Parameter(
+    "infisical-ssm-auth-secret",
+    name="/infisical/AUTH_SECRET",
+    type="SecureString",
+    value=auth_secret,
+    tags=_COST_TAGS,
+)
 
 # ---------------------------------------------------------------------------
 # CloudWatch Log Group
@@ -41,19 +77,20 @@ log_group = aws.cloudwatch.LogGroup(
 )
 
 # ---------------------------------------------------------------------------
-# Security Group — allow inbound 443 (HTTPS)
+# Security Group — allow inbound 443 (HTTPS) from configurable CIDR
 # ---------------------------------------------------------------------------
 infisical_sg = aws.ec2.SecurityGroup(
     "infisical-sg",
     name="infisical-sg",
     description="Allow inbound HTTPS traffic to Infisical",
+    vpc_id=vpc_id,
     ingress=[
         aws.ec2.SecurityGroupIngressArgs(
             protocol="tcp",
             from_port=443,
             to_port=443,
-            cidr_blocks=["0.0.0.0/0"],
-            description="HTTPS inbound",
+            cidr_blocks=ingress_cidr_blocks,
+            description="HTTPS inbound from VPC CIDR",
         ),
     ],
     egress=[
@@ -76,15 +113,15 @@ _region = aws_config.require("region")
 
 container_definitions = pulumi.Output.all(
     log_group.name,
-    mongo_url,
-    encryption_key,
-    auth_secret,
+    ssm_mongo_url.arn,
+    ssm_encryption_key.arn,
+    ssm_auth_secret.arn,
 ).apply(
     lambda args: json.dumps(
         [
             {
                 "name": "infisical",
-                "image": "infisical/infisical:latest",
+                "image": "infisical/infisical:v0.91.0",
                 "cpu": 512,
                 "memory": 1024,
                 "essential": True,
@@ -95,11 +132,13 @@ container_definitions = pulumi.Output.all(
                     }
                 ],
                 "environment": [
-                    {"name": "MONGO_URL", "value": args[1]},
-                    {"name": "ENCRYPTION_KEY", "value": args[2]},
-                    {"name": "AUTH_SECRET", "value": args[3]},
                     {"name": "SITE_URL", "value": site_url},
                     {"name": "NODE_ENV", "value": "production"},
+                ],
+                "secrets": [
+                    {"name": "MONGO_URL", "valueFrom": args[1]},
+                    {"name": "ENCRYPTION_KEY", "valueFrom": args[2]},
+                    {"name": "AUTH_SECRET", "valueFrom": args[3]},
                 ],
                 "logConfiguration": {
                     "logDriver": "awslogs",
@@ -140,8 +179,7 @@ infisical_service = aws.ecs.Service(
     network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
         assign_public_ip=False,
         security_groups=[infisical_sg.id],
-        # TODO(#86): Add subnet IDs once VPC resources are available
-        subnets=[],
+        subnets=subnet_ids,
     ),
     tags=_COST_TAGS,
 )

--- a/infra/infisical.py
+++ b/infra/infisical.py
@@ -44,7 +44,7 @@ _COST_TAGS = {
 # ---------------------------------------------------------------------------
 ssm_mongo_url = aws.ssm.Parameter(
     "infisical-ssm-mongo-url",
-    name="/infisical/MONGO_URL",
+    name=f"/infisical/{pulumi.get_stack()}/MONGO_URL",
     type="SecureString",
     value=mongo_url,
     tags=_COST_TAGS,
@@ -52,7 +52,7 @@ ssm_mongo_url = aws.ssm.Parameter(
 
 ssm_encryption_key = aws.ssm.Parameter(
     "infisical-ssm-encryption-key",
-    name="/infisical/ENCRYPTION_KEY",
+    name=f"/infisical/{pulumi.get_stack()}/ENCRYPTION_KEY",
     type="SecureString",
     value=encryption_key,
     tags=_COST_TAGS,
@@ -60,7 +60,7 @@ ssm_encryption_key = aws.ssm.Parameter(
 
 ssm_auth_secret = aws.ssm.Parameter(
     "infisical-ssm-auth-secret",
-    name="/infisical/AUTH_SECRET",
+    name=f"/infisical/{pulumi.get_stack()}/AUTH_SECRET",
     type="SecureString",
     value=auth_secret,
     tags=_COST_TAGS,
@@ -90,7 +90,7 @@ infisical_sg = aws.ec2.SecurityGroup(
             from_port=443,
             to_port=443,
             cidr_blocks=ingress_cidr_blocks,
-            description="HTTPS inbound from VPC CIDR",
+            description="HTTPS inbound from configured CIDR",
         ),
     ],
     egress=[

--- a/tests/test_infisical_infra.py
+++ b/tests/test_infisical_infra.py
@@ -96,6 +96,69 @@ def test_contains_mongo_url_env_var():
 
 
 # ---------------------------------------------------------------------------
+# Hardening: subnet IDs from Pulumi config (#242)
+# ---------------------------------------------------------------------------
+
+
+def test_subnets_from_config():
+    """network_configuration.subnets must use values from Pulumi config, not an empty list."""
+    src = _infisical_source()
+    # Must read subnet IDs from a Pulumi Config (e.g. config.require_object or config.require)
+    assert "subnet" in src.lower(), "Must reference subnet configuration"
+    # Must NOT have an empty subnets=[]
+    assert "subnets=[]" not in src, "subnets must not be an empty list"
+
+
+# ---------------------------------------------------------------------------
+# Hardening: SecurityGroup vpc_id (#242)
+# ---------------------------------------------------------------------------
+
+
+def test_security_group_has_vpc_id():
+    """SecurityGroup must have vpc_id explicitly set from Pulumi config."""
+    src = _infisical_source()
+    assert "vpc_id" in src, "SecurityGroup must have vpc_id explicitly set"
+
+
+# ---------------------------------------------------------------------------
+# Hardening: Ingress CIDR restriction (#242)
+# ---------------------------------------------------------------------------
+
+
+def test_ingress_not_open_to_world():
+    """Ingress must NOT use 0.0.0.0/0; should use a configurable CIDR."""
+    src = _infisical_source()
+    assert "0.0.0.0/0" not in src.split("ingress")[1].split("egress")[0], "Ingress CIDR must not be 0.0.0.0/0"
+
+
+# ---------------------------------------------------------------------------
+# Hardening: Secrets via SSM Parameter Store (#242)
+# ---------------------------------------------------------------------------
+
+
+def test_secrets_use_ssm_parameter_store():
+    """Sensitive env vars must use SSM Parameter Store via ECS secrets field."""
+    src = _infisical_source()
+    # Must create SSM Parameters for secrets
+    assert "ssm.Parameter(" in src, "Must define SSM Parameters for secrets"
+    # Container definition must use 'secrets' field, not plain 'environment' for sensitive values
+    assert '"secrets"' in src, "Container definition must use ECS secrets field for sensitive values"
+    assert '"valueFrom"' in src, "Secrets must use valueFrom to reference SSM parameters"
+
+
+# ---------------------------------------------------------------------------
+# Hardening: Pinned Docker image version (#242)
+# ---------------------------------------------------------------------------
+
+
+def test_docker_image_pinned():
+    """Docker image must be pinned to a specific version, not :latest."""
+    src = _infisical_source()
+    assert "infisical/infisical:latest" not in src, "Docker image must not use :latest tag"
+    assert "infisical/infisical:v0.91.0" in src, "Docker image must be pinned to v0.91.0"
+
+
+# ---------------------------------------------------------------------------
 # __main__.py integration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_infisical_infra.py
+++ b/tests/test_infisical_infra.py
@@ -89,10 +89,10 @@ def test_infisical_naming():
 # ---------------------------------------------------------------------------
 
 
-def test_contains_mongo_url_env_var():
-    """Container definition must reference MONGO_URL environment variable."""
+def test_contains_mongo_url_secret():
+    """Container definition must reference MONGO_URL via SSM secrets."""
     src = _infisical_source()
-    assert "MONGO_URL" in src, "Container definition must include MONGO_URL environment variable"
+    assert "MONGO_URL" in src, "Container definition must include MONGO_URL secret"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Retrieve subnet IDs from Pulumi config instead of empty list
- Set `vpc_id` explicitly on SecurityGroup from Pulumi config
- Restrict ingress CIDR from `0.0.0.0/0` to configurable VPC CIDR
- Migrate container secrets (MONGO_URL, ENCRYPTION_KEY, AUTH_SECRET) from `environment` to SSM Parameter Store + ECS `secrets` field
- Pin Docker image to `infisical/infisical:v0.91.0`
- Namespace SSM parameter paths with `pulumi.get_stack()`

Closes #242