### PR TITLE
refactor: ♻️ consolidate test helpers into shared module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["tests"]
 markers = [
     "small: Fast unit tests (no network, no disk beyond tmp_path, no DB)",
     "medium: Integration tests (may use network, disk, or local services)",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,56 @@
+"""Shared test helper functions for workflow and handler tests."""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+
+
+def load_workflow(path: Path) -> dict:
+    """Load workflow YAML and return parsed dict.
+
+    *path* should be an absolute ``Path`` to a workflow YAML file.
+    """
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict), "Workflow YAML must be a valid mapping"
+    return data
+
+
+def get_on_block(data: dict) -> dict:
+    """Return the ``on`` trigger block from a parsed workflow.
+
+    PyYAML parses the bare YAML key ``on`` as boolean ``True``, so this
+    helper checks both ``True`` and ``"on"`` keys.
+    """
+    return data.get(True, data.get("on", {}))
+
+
+def is_sha_pinned(ref: str) -> bool:
+    """Return *True* if *ref* is pinned to a full 40-char commit SHA."""
+    _, _, version = ref.partition("@")
+    return bool(re.fullmatch(r"[0-9a-f]{40}", version))
+
+
+def load_handler(handler_dir: str | Path) -> object:
+    """Dynamically import ``handler`` module from *handler_dir*.
+
+    The directory is temporarily prepended to ``sys.path`` and cleaned up
+    after import.
+    """
+    handler_dir = str(handler_dir)
+    original_path = sys.path.copy()
+    try:
+        if handler_dir not in sys.path:
+            sys.path.insert(0, handler_dir)
+        if "handler" in sys.modules:
+            return importlib.reload(sys.modules["handler"])
+        return importlib.import_module("handler")
+    finally:
+        sys.path[:] = original_path

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,7 +16,7 @@ WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 def load_workflow(path: Path) -> dict:
     """Load workflow YAML and return parsed dict.
 
-    *path* should be an absolute ``Path`` to a workflow YAML file.
+    *path* can be absolute or relative to the project root.
     """
     data = yaml.safe_load(path.read_text())
     assert isinstance(data, dict), "Workflow YAML must be a valid mapping"
@@ -41,16 +41,20 @@ def is_sha_pinned(ref: str) -> bool:
 def load_handler(handler_dir: str | Path) -> object:
     """Dynamically import ``handler`` module from *handler_dir*.
 
-    The directory is temporarily prepended to ``sys.path`` and cleaned up
-    after import.
+    Uses ``importlib.util.spec_from_file_location`` with a unique module name
+    to avoid conflicts between different handler directories.
     """
-    handler_dir = str(handler_dir)
-    original_path = sys.path.copy()
-    try:
-        if handler_dir not in sys.path:
-            sys.path.insert(0, handler_dir)
-        if "handler" in sys.modules:
-            return importlib.reload(sys.modules["handler"])
-        return importlib.import_module("handler")
-    finally:
-        sys.path[:] = original_path
+    handler_dir = Path(handler_dir)
+    handler_file = handler_dir / "handler.py"
+    module_name = f"handler_{handler_dir.name}"
+
+    # Remove stale entry if exists
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, handler_file)
+    assert spec is not None and spec.loader is not None, f"Cannot load handler from {handler_file}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_ci_optimization.py
+++ b/tests/test_ci_optimization.py
@@ -1,17 +1,6 @@
 """Tests for CI pipeline optimization strategy."""
 
-from pathlib import Path
-
-import yaml
-
-WORKFLOWS_DIR = Path(__file__).parent.parent / ".github" / "workflows"
-
-
-def _load_workflow(name: str) -> dict:
-    path = WORKFLOWS_DIR / name
-    data = yaml.safe_load(path.read_text())
-    assert isinstance(data, dict)
-    return data
+from helpers import WORKFLOWS_DIR, load_workflow
 
 
 def _get_triggers(data: dict) -> dict:
@@ -24,7 +13,7 @@ def _get_triggers(data: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# uv cache — all setup-uv steps should enable caching
+# uv cache -- all setup-uv steps should enable caching
 # ---------------------------------------------------------------------------
 
 
@@ -40,19 +29,19 @@ def test_pulumi_preview_uses_uv_cache():
 
 
 # ---------------------------------------------------------------------------
-# paths filter — lint.yml should only run on relevant changes
+# paths filter -- lint.yml should only run on relevant changes
 # ---------------------------------------------------------------------------
 
 
 def test_lint_workflow_has_paths_filter():
-    data = _load_workflow("lint.yml")
+    data = load_workflow(WORKFLOWS_DIR / "lint.yml")
     triggers = _get_triggers(data)
     pr_config = triggers.get("pull_request", {})
     assert "paths" in pr_config, "lint.yml should have paths filter on pull_request"
 
 
 def test_lint_workflow_paths_include_infra_and_tests():
-    data = _load_workflow("lint.yml")
+    data = load_workflow(WORKFLOWS_DIR / "lint.yml")
     triggers = _get_triggers(data)
     paths = triggers["pull_request"]["paths"]
     path_str = " ".join(paths)

--- a/tests/test_container_build_workflow.py
+++ b/tests/test_container_build_workflow.py
@@ -2,19 +2,9 @@
 
 from pathlib import Path
 
-import yaml
+from helpers import get_on_block, is_sha_pinned, load_workflow
 
 WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "container-build.yml"
-
-
-def _load_workflow() -> dict:
-    """Load workflow YAML, handling 'on' key parsed as boolean True."""
-    return yaml.safe_load(WORKFLOW_PATH.read_text())
-
-
-def _get_on_block(data: dict) -> dict:
-    """Get the 'on' trigger block (YAML parses bare 'on' as True)."""
-    return data.get(True, data.get("on", {}))
 
 
 def test_workflow_file_exists():
@@ -22,14 +12,14 @@ def test_workflow_file_exists():
 
 
 def test_workflow_is_valid_yaml():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     assert isinstance(data, dict), "Workflow must be a valid YAML mapping"
 
 
 def test_pr_trigger_excludes_rust_paths():
     """PR trigger should include container/** but exclude Rust paths (verified by rust.yml)."""
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     pr_trigger = on_block.get("pull_request", {})
     paths = pr_trigger.get("paths", [])
     assert "container/**" in paths, "Must filter on container/** path"
@@ -40,16 +30,16 @@ def test_pr_trigger_excludes_rust_paths():
 
 def test_push_to_main_triggers_build():
     """Push to main should trigger container build for full verification."""
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     push_trigger = on_block.get("push", {})
     branches = push_trigger.get("branches", [])
     assert "main" in branches, "Must trigger on push to main"
 
 
 def test_pull_request_trigger_types():
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     pr_trigger = on_block["pull_request"]
     types = pr_trigger.get("types", [])
     assert "opened" in types
@@ -58,15 +48,15 @@ def test_pull_request_trigger_types():
 
 
 def test_has_permissions_block():
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    data = load_workflow(WORKFLOW_PATH)
     permissions = data.get("permissions", {})
     assert "contents" in permissions, "Must declare contents permission"
     assert permissions["contents"] == "read"
 
 
 def test_builds_docker_image():
-    """Build step must exist — either as a run command or a docker/build-push-action."""
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    """Build step must exist -- either as a run command or a docker/build-push-action."""
+    data = load_workflow(WORKFLOW_PATH)
     run_steps = []
     uses_steps = []
     for job in data.get("jobs", {}).values():
@@ -82,7 +72,7 @@ def test_builds_docker_image():
 
 def test_no_expression_interpolation_in_run_blocks():
     """Ensure no ${{ }} expressions appear in run: blocks (security best practice)."""
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    data = load_workflow(WORKFLOW_PATH)
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             if "run" in step:
@@ -92,15 +82,12 @@ def test_no_expression_interpolation_in_run_blocks():
 
 
 def test_uses_actions_checkout_sha_pinned():
-    import re
-
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    data = load_workflow(WORKFLOW_PATH)
     checkout_found = False
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             uses = step.get("uses", "")
             if "actions/checkout" in uses:
-                _, _, ref = uses.partition("@")
-                assert re.fullmatch(r"[0-9a-f]{40}", ref), f"actions/checkout must be SHA-pinned, got: {uses}"
+                assert is_sha_pinned(uses), f"actions/checkout must be SHA-pinned, got: {uses}"
                 checkout_found = True
     assert checkout_found, "Must use actions/checkout"

--- a/tests/test_kanban_sync_workflow.py
+++ b/tests/test_kanban_sync_workflow.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-import yaml
+from helpers import get_on_block, load_workflow
 
 WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "kanban-sync.yml"
 
@@ -15,9 +15,9 @@ EXPECTED_LABELS = [
 ]
 
 
-def _load_workflow() -> dict:
+def _load_kanban_workflow() -> dict:
     """Load and parse the workflow YAML."""
-    return yaml.safe_load(WORKFLOW_PATH.read_text())
+    return load_workflow(WORKFLOW_PATH)
 
 
 def test_workflow_file_exists():
@@ -27,15 +27,15 @@ def test_workflow_file_exists():
 
 def test_workflow_is_valid_yaml():
     """Workflow file must be valid YAML that parses without error."""
-    data = _load_workflow()
+    data = _load_kanban_workflow()
     assert isinstance(data, dict)
 
 
 def test_trigger_on_issues_labeled():
     """Workflow must trigger on issues labeled event."""
-    data = _load_workflow()
-    triggers = data.get(True, data.get("on", {}))
-    issues_cfg = triggers.get("issues", {})
+    data = _load_kanban_workflow()
+    on_block = get_on_block(data)
+    issues_cfg = on_block.get("issues", {})
     assert "labeled" in issues_cfg.get("types", [])
 
 
@@ -48,7 +48,7 @@ def test_references_all_state_labels():
 
 def test_has_permissions_block():
     """Workflow must declare a permissions block."""
-    data = _load_workflow()
+    data = _load_kanban_workflow()
     assert "permissions" in data, "Top-level permissions block missing"
     perms = data["permissions"]
     assert "issues" in perms
@@ -57,7 +57,7 @@ def test_has_permissions_block():
 
 def test_no_expression_injection_in_run_blocks():
     """Run blocks must not contain ${{ }} expressions (security)."""
-    data = _load_workflow()
+    data = _load_kanban_workflow()
     jobs = data.get("jobs", {})
     for job_name, job_cfg in jobs.items():
         for step in job_cfg.get("steps", []):

--- a/tests/test_petri_workflow.py
+++ b/tests/test_petri_workflow.py
@@ -3,20 +3,9 @@
 import re
 from pathlib import Path
 
-import yaml
+from helpers import get_on_block, load_workflow
 
 WORKFLOW_PATH = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "petri-preview.yml"
-
-
-def _load_workflow() -> dict:
-    assert WORKFLOW_PATH.is_file(), "petri-preview.yml must exist"
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
-    assert isinstance(data, dict)
-    return data
-
-
-def _get_on_block(data: dict) -> dict:
-    return data.get(True, data.get("on", {}))
 
 
 def test_workflow_exists():
@@ -24,8 +13,8 @@ def test_workflow_exists():
 
 
 def test_triggers_on_pr_open_and_close():
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     pr = on_block.get("pull_request", {})
     types = pr.get("types", [])
     assert "opened" in types, "Must trigger on PR opened"
@@ -34,19 +23,19 @@ def test_triggers_on_pr_open_and_close():
 
 
 def test_has_deploy_job():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     jobs = data.get("jobs", {})
     assert "deploy" in jobs or "preview-deploy" in jobs, "Must have a deploy job"
 
 
 def test_has_cleanup_job():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     jobs = data.get("jobs", {})
     assert "cleanup" in jobs or "preview-cleanup" in jobs, "Must have a cleanup job"
 
 
 def test_cleanup_runs_on_pr_close():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     jobs = data.get("jobs", {})
     cleanup_job = jobs.get("cleanup") or jobs.get("preview-cleanup")
     assert cleanup_job is not None
@@ -62,7 +51,7 @@ def test_uses_pr_number_for_naming():
 
 
 def test_has_permissions():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     assert "permissions" in data
 
 

--- a/tests/test_pr_cleanup_handler.py
+++ b/tests/test_pr_cleanup_handler.py
@@ -4,19 +4,21 @@ Validates that the handler module exists, has the expected entry point,
 and returns the correct response format.
 """
 
-import importlib
 import json
-import sys
 from pathlib import Path
+
+from helpers import load_handler
 
 # ---------------------------------------------------------------------------
 # Module existence
 # ---------------------------------------------------------------------------
 
+HANDLER_DIR = Path(__file__).resolve().parent.parent / "lambda" / "pr_cleanup"
+
 
 def test_handler_module_exists():
     """lambda/pr_cleanup/handler.py must exist."""
-    handler_path = Path(__file__).resolve().parent.parent / "lambda" / "pr_cleanup" / "handler.py"
+    handler_path = HANDLER_DIR / "handler.py"
     assert handler_path.is_file(), "lambda/pr_cleanup/handler.py must exist"
 
 
@@ -25,30 +27,16 @@ def test_handler_module_exists():
 # ---------------------------------------------------------------------------
 
 
-def _load_handler():
-    """Import the handler module dynamically."""
-    handler_dir = str(Path(__file__).resolve().parent.parent / "lambda" / "pr_cleanup")
-    original_path = sys.path.copy()
-    try:
-        if handler_dir not in sys.path:
-            sys.path.insert(0, handler_dir)
-        if "handler" in sys.modules:
-            return importlib.reload(sys.modules["handler"])
-        return importlib.import_module("handler")
-    finally:
-        sys.path[:] = original_path
-
-
 def test_handler_has_handle_function():
     """handler module must expose a 'handle' function."""
-    mod = _load_handler()
+    mod = load_handler(HANDLER_DIR)
     assert hasattr(mod, "handle"), "handler module must have a 'handle' function"
     assert callable(mod.handle)
 
 
 def test_handler_returns_status_code():
     """handle() must return a dict with 'statusCode'."""
-    mod = _load_handler()
+    mod = load_handler(HANDLER_DIR)
     event = {
         "detail": {
             "action": "closed",
@@ -62,7 +50,7 @@ def test_handler_returns_status_code():
 
 def test_handler_returns_200_on_valid_event():
     """handle() must return 200 for a valid PR close event."""
-    mod = _load_handler()
+    mod = load_handler(HANDLER_DIR)
     event = {
         "detail": {
             "action": "closed",
@@ -75,7 +63,7 @@ def test_handler_returns_200_on_valid_event():
 
 def test_handler_body_contains_pr_number():
     """Response body must reference the PR number."""
-    mod = _load_handler()
+    mod = load_handler(HANDLER_DIR)
     event = {
         "detail": {
             "action": "closed",

--- a/tests/test_pulumi_preview_workflow.py
+++ b/tests/test_pulumi_preview_workflow.py
@@ -3,27 +3,20 @@
 import re
 from pathlib import Path
 
-import yaml
+from helpers import load_workflow
 
 WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pulumi-preview.yml"
 
 
-def _load_workflow() -> dict:
-    """Load and parse the workflow YAML."""
-    assert WORKFLOW_PATH.exists(), f"Workflow file not found: {WORKFLOW_PATH}"
-    content = WORKFLOW_PATH.read_text()
-    return yaml.safe_load(content)
-
-
 def test_workflow_file_exists_and_is_valid_yaml():
     """The workflow file must exist and be parseable YAML."""
-    wf = _load_workflow()
+    wf = load_workflow(WORKFLOW_PATH)
     assert isinstance(wf, dict)
 
 
 def test_trigger_on_pull_request_with_paths_filter():
     """Workflow triggers on pull_request with paths filter for infra/**."""
-    wf = _load_workflow()
+    wf = load_workflow(WORKFLOW_PATH)
     # PyYAML parses bare `on` as boolean True
     pr_trigger = wf.get("on") or wf.get(True)
     pr_trigger = pr_trigger["pull_request"]
@@ -41,7 +34,7 @@ def test_references_pulumi_actions():
 
 def test_permissions_are_correct():
     """Workflow needs contents:read and pull-requests:write."""
-    wf = _load_workflow()
+    wf = load_workflow(WORKFLOW_PATH)
     # Permissions can be at top-level or job-level
     perms = wf.get("permissions") or {}
     # Also check job-level permissions
@@ -57,7 +50,7 @@ def test_permissions_are_correct():
 
 def test_no_direct_interpolation_in_run_blocks():
     """No direct ${{ }} interpolation in run: blocks (security)."""
-    wf = _load_workflow()
+    wf = load_workflow(WORKFLOW_PATH)
     for job_name, job in wf.get("jobs", {}).items():
         if not isinstance(job, dict):
             continue

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -3,26 +3,11 @@
 import re
 from pathlib import Path
 
-import yaml
+from helpers import get_on_block, is_sha_pinned, load_workflow
 
 ROOT = Path(__file__).parent.parent
 CHANGELOG_PATH = ROOT / "CHANGELOG.md"
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "release.yml"
-
-
-def _load_workflow() -> dict:
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
-    assert isinstance(data, dict), "Workflow YAML must be a valid mapping"
-    return data
-
-
-def _get_on_block(data: dict) -> dict:
-    return data.get(True, data.get("on", {}))
-
-
-def _is_sha_pinned(ref: str) -> bool:
-    _, _, version = ref.partition("@")
-    return bool(re.fullmatch(r"[0-9a-f]{40}", version))
 
 
 # ── CHANGELOG.md ──
@@ -60,38 +45,38 @@ def test_release_workflow_exists():
 
 
 def test_release_triggers_on_tag_push():
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     push = on_block.get("push", {})
     tags = push.get("tags", [])
     assert any("v*" in t or "v**" in t for t in tags), "Must trigger on v* tag push"
 
 
 def test_release_has_permissions():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     permissions = data.get("permissions", {})
     assert "contents" in permissions, "Must declare contents permission"
 
 
 def test_release_has_concurrency():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     assert "concurrency" in data, "Must have concurrency block"
     concurrency = data["concurrency"]
     assert "group" in concurrency
 
 
 def test_release_all_actions_sha_pinned():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     for job_name, job in data.get("jobs", {}).items():
         for step in job.get("steps", []):
             uses = step.get("uses", "")
             if uses and "/" in uses:
-                assert _is_sha_pinned(uses), f"Action must be SHA-pinned in job '{job_name}', got: {uses}"
+                assert is_sha_pinned(uses), f"Action must be SHA-pinned in job '{job_name}', got: {uses}"
 
 
 def test_release_creates_github_release():
     """Release job must create a GitHub release (via gh CLI or action)."""
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     all_steps = []
     for job in data.get("jobs", {}).values():
         all_steps.extend(job.get("steps", []))

--- a/tests/test_rust_ci_workflow.py
+++ b/tests/test_rust_ci_workflow.py
@@ -1,26 +1,10 @@
 """Tests for Rust CI workflow configuration."""
 
-import re
 from pathlib import Path
 
-import yaml
+from helpers import get_on_block, is_sha_pinned, load_workflow
 
 WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "rust.yml"
-
-
-def _load_workflow() -> dict:
-    data = yaml.safe_load(WORKFLOW_PATH.read_text())
-    assert isinstance(data, dict), "Workflow YAML must be a valid mapping"
-    return data
-
-
-def _get_on_block(data: dict) -> dict:
-    return data.get(True, data.get("on", {}))
-
-
-def _is_sha_pinned(ref: str) -> bool:
-    _, _, version = ref.partition("@")
-    return bool(re.fullmatch(r"[0-9a-f]{40}", version))
 
 
 # ── structure ──
@@ -31,13 +15,13 @@ def test_workflow_file_exists():
 
 
 def test_has_permissions_block():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     permissions = data.get("permissions", {})
     assert permissions.get("contents") == "read", "Must declare contents: read"
 
 
 def test_has_concurrency_block():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     assert "concurrency" in data, "Must have concurrency block"
     concurrency = data["concurrency"]
     assert "group" in concurrency
@@ -45,8 +29,8 @@ def test_has_concurrency_block():
 
 
 def test_triggers_on_pull_request_with_paths():
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     pr = on_block.get("pull_request", {})
     paths = pr.get("paths", [])
     assert "crates/**" in paths
@@ -57,19 +41,19 @@ def test_triggers_on_pull_request_with_paths():
 
 
 def test_has_lint_job():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     assert "lint" in data["jobs"], "Must have separate lint job"
 
 
 def test_lint_job_runs_fmt():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     steps = data["jobs"]["lint"].get("steps", [])
     run_cmds = [s["run"] for s in steps if "run" in s]
     assert any("cargo fmt" in cmd for cmd in run_cmds)
 
 
 def test_lint_job_runs_clippy():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     steps = data["jobs"]["lint"].get("steps", [])
     run_cmds = [s["run"] for s in steps if "run" in s]
     assert any("cargo clippy" in cmd for cmd in run_cmds)
@@ -79,12 +63,12 @@ def test_lint_job_runs_clippy():
 
 
 def test_has_test_job():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     assert "test" in data["jobs"], "Must have separate test job"
 
 
 def test_test_job_uses_llvm_cov():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     steps = data["jobs"]["test"].get("steps", [])
     run_cmds = [s["run"] for s in steps if "run" in s]
     uses_refs = [s["uses"] for s in steps if "uses" in s]
@@ -93,7 +77,7 @@ def test_test_job_uses_llvm_cov():
 
 
 def test_test_job_enforces_coverage_threshold():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     steps = data["jobs"]["test"].get("steps", [])
     run_cmds = [s["run"] for s in steps if "run" in s]
     assert any("fail-under-lines" in cmd for cmd in run_cmds), "Must enforce coverage threshold"
@@ -103,9 +87,9 @@ def test_test_job_enforces_coverage_threshold():
 
 
 def test_all_actions_sha_pinned():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             uses = step.get("uses", "")
             if uses and "/" in uses:
-                assert _is_sha_pinned(uses), f"Action must be SHA-pinned, got: {uses}"
+                assert is_sha_pinned(uses), f"Action must be SHA-pinned, got: {uses}"

--- a/tests/test_shared_workflows.py
+++ b/tests/test_shared_workflows.py
@@ -2,20 +2,10 @@
 
 from pathlib import Path
 
-import yaml
+from helpers import get_on_block, is_sha_pinned, load_workflow
 
 REUSABLE_CI_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "reusable-python-ci.yml"
 LINT_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "lint.yml"
-
-
-def _load_workflow(path: Path) -> dict:
-    """Load workflow YAML, handling 'on' key parsed as boolean True."""
-    return yaml.safe_load(path.read_text())
-
-
-def _get_on_block(data: dict) -> dict:
-    """Get the 'on' trigger block (YAML parses bare 'on' as True)."""
-    return data.get(True, data.get("on", {}))
 
 
 # ── reusable-python-ci.yml existence & validity ──
@@ -26,7 +16,7 @@ def test_reusable_workflow_file_exists():
 
 
 def test_reusable_workflow_is_valid_yaml():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     assert isinstance(data, dict), "Workflow must be a valid YAML mapping"
 
 
@@ -34,14 +24,14 @@ def test_reusable_workflow_is_valid_yaml():
 
 
 def test_has_workflow_call_trigger():
-    data = _load_workflow(REUSABLE_CI_PATH)
-    on_block = _get_on_block(data)
+    data = load_workflow(REUSABLE_CI_PATH)
+    on_block = get_on_block(data)
     assert "workflow_call" in on_block, "Must have workflow_call trigger"
 
 
 def test_workflow_call_has_python_version_input():
-    data = _load_workflow(REUSABLE_CI_PATH)
-    on_block = _get_on_block(data)
+    data = load_workflow(REUSABLE_CI_PATH)
+    on_block = get_on_block(data)
     inputs = on_block["workflow_call"].get("inputs", {})
     pv = inputs.get("python_version", {})
     assert pv, "Must define python_version input"
@@ -49,8 +39,8 @@ def test_workflow_call_has_python_version_input():
 
 
 def test_workflow_call_has_run_tests_input():
-    data = _load_workflow(REUSABLE_CI_PATH)
-    on_block = _get_on_block(data)
+    data = load_workflow(REUSABLE_CI_PATH)
+    on_block = get_on_block(data)
     inputs = on_block["workflow_call"].get("inputs", {})
     rt = inputs.get("run_tests", {})
     assert rt, "Must define run_tests input"
@@ -58,8 +48,8 @@ def test_workflow_call_has_run_tests_input():
 
 
 def test_workflow_call_has_run_lint_input():
-    data = _load_workflow(REUSABLE_CI_PATH)
-    on_block = _get_on_block(data)
+    data = load_workflow(REUSABLE_CI_PATH)
+    on_block = get_on_block(data)
     inputs = on_block["workflow_call"].get("inputs", {})
     rl = inputs.get("run_lint", {})
     assert rl, "Must define run_lint input"
@@ -70,33 +60,33 @@ def test_workflow_call_has_run_lint_input():
 
 
 def test_defines_lint_job():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     jobs = data.get("jobs", {})
     assert "lint" in jobs, "Must define lint job"
 
 
 def test_defines_test_job():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     jobs = data.get("jobs", {})
     assert "test" in jobs, "Must define test job"
 
 
 def test_lint_job_runs_ruff_check():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     lint_steps = data["jobs"]["lint"].get("steps", [])
     run_cmds = [s["run"] for s in lint_steps if "run" in s]
     assert any("ruff check" in cmd for cmd in run_cmds), "lint job must run ruff check"
 
 
 def test_lint_job_runs_ruff_format():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     lint_steps = data["jobs"]["lint"].get("steps", [])
     run_cmds = [s["run"] for s in lint_steps if "run" in s]
     assert any("ruff format" in cmd for cmd in run_cmds), "lint job must run ruff format"
 
 
 def test_test_job_runs_pytest_with_markers():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     test_steps = data["jobs"]["test"].get("steps", [])
     run_cmds = [s["run"] for s in test_steps if "run" in s]
     assert any("pytest" in cmd and "small or medium" in cmd for cmd in run_cmds), (
@@ -107,40 +97,32 @@ def test_test_job_runs_pytest_with_markers():
 # ── actions versions ──
 
 
-def _is_sha_pinned(ref: str) -> bool:
-    """Check if an action ref is pinned to a full commit SHA (40 hex chars)."""
-    import re
-
-    _, _, version = ref.partition("@")
-    return bool(re.fullmatch(r"[0-9a-f]{40}", version))
-
-
 def test_uses_actions_checkout_sha_pinned():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     checkout_found = False
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             uses = step.get("uses", "")
             if "actions/checkout" in uses:
-                assert _is_sha_pinned(uses), f"actions/checkout must be SHA-pinned, got: {uses}"
+                assert is_sha_pinned(uses), f"actions/checkout must be SHA-pinned, got: {uses}"
                 checkout_found = True
     assert checkout_found, "Must use actions/checkout"
 
 
 def test_uses_setup_uv_sha_pinned():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     uv_found = False
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             uses = step.get("uses", "")
             if "setup-uv" in uses:
-                assert _is_sha_pinned(uses), f"astral-sh/setup-uv must be SHA-pinned, got: {uses}"
+                assert is_sha_pinned(uses), f"astral-sh/setup-uv must be SHA-pinned, got: {uses}"
                 uv_found = True
     assert uv_found, "Must use astral-sh/setup-uv"
 
 
 def test_setup_uv_enables_cache():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             if "setup-uv" in step.get("uses", ""):
@@ -152,7 +134,7 @@ def test_setup_uv_enables_cache():
 
 
 def test_has_contents_read_permission():
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     permissions = data.get("permissions", {})
     assert permissions.get("contents") == "read", "Must declare contents: read"
 
@@ -162,7 +144,7 @@ def test_has_contents_read_permission():
 
 def test_no_expression_interpolation_in_run_blocks():
     """Ensure no ${{ }} expressions appear in run: blocks."""
-    data = _load_workflow(REUSABLE_CI_PATH)
+    data = load_workflow(REUSABLE_CI_PATH)
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             if "run" in step:
@@ -176,7 +158,7 @@ def test_no_expression_interpolation_in_run_blocks():
 
 def test_lint_yml_calls_reusable_workflow():
     """lint.yml should delegate to the reusable workflow."""
-    data = _load_workflow(LINT_PATH)
+    data = load_workflow(LINT_PATH)
     jobs = data.get("jobs", {})
     uses_reusable = False
     for job in jobs.values():

--- a/tests/test_verify_workflow.py
+++ b/tests/test_verify_workflow.py
@@ -2,19 +2,9 @@
 
 from pathlib import Path
 
-import yaml
+from helpers import get_on_block, load_workflow
 
 WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "myxo-verify.yml"
-
-
-def _load_workflow() -> dict:
-    """Load workflow YAML, handling 'on' key parsed as boolean True."""
-    return yaml.safe_load(WORKFLOW_PATH.read_text())
-
-
-def _get_on_block(data: dict) -> dict:
-    """Get the 'on' trigger block (YAML parses bare 'on' as True)."""
-    return data.get(True, data.get("on", {}))
 
 
 def test_workflow_file_exists():
@@ -22,13 +12,13 @@ def test_workflow_file_exists():
 
 
 def test_workflow_is_valid_yaml():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     assert isinstance(data, dict), "Workflow must be a valid YAML mapping"
 
 
 def test_has_schedule_trigger_with_cron():
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     schedule = on_block.get("schedule")
     assert schedule is not None, "Must have schedule trigger"
     assert isinstance(schedule, list), "schedule must be a list"
@@ -37,13 +27,13 @@ def test_has_schedule_trigger_with_cron():
 
 
 def test_has_workflow_dispatch_trigger():
-    data = _load_workflow()
-    on_block = _get_on_block(data)
+    data = load_workflow(WORKFLOW_PATH)
+    on_block = get_on_block(data)
     assert "workflow_dispatch" in on_block, "Must have workflow_dispatch trigger"
 
 
 def test_references_mxl_verify_in_run_blocks():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     run_steps = []
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
@@ -55,14 +45,14 @@ def test_references_mxl_verify_in_run_blocks():
 
 
 def test_has_permissions():
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     permissions = data.get("permissions", {})
     assert permissions.get("contents") == "read", "Must have contents: read permission"
 
 
 def test_no_expression_interpolation_in_run_blocks():
     """Ensure no ${{ }} expressions appear in run: blocks (security best practice)."""
-    data = _load_workflow()
+    data = load_workflow(WORKFLOW_PATH)
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             if "run" in step:


### PR DESCRIPTION
## Summary
- Extract duplicated helper functions (`_load_workflow`, `_get_on_block`, `_is_sha_pinned`, `_load_handler`) into `tests/helpers.py`
- Update 11 test files to import from the shared module instead of defining their own copies
- Add `pythonpath = ["tests"]` to `pyproject.toml` for module resolution

Closes #251