### PR TITLE
refactor: ♻️ centralize infra constants and unify config naming

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -4,6 +4,7 @@ import secrets
 
 import cleanup
 import common
+import constants
 import ecs
 import frontend_preview
 import github_app
@@ -18,6 +19,7 @@ import stale_cleanup
 __all__ = [
     "cleanup",
     "common",
+    "constants",
     "ecs",
     "frontend_preview",
     "github_app",

--- a/infra/cleanup.py
+++ b/infra/cleanup.py
@@ -13,6 +13,7 @@ import json
 import common
 import pulumi
 import pulumi_aws as aws
+from constants import LOG_RETENTION_DAYS
 
 iam = aws.iam
 cloudwatch = aws.cloudwatch
@@ -21,6 +22,7 @@ cloudwatch = aws.cloudwatch
 cleanup_log_group = common.create_log_group(
     "myxo-pr-cleanup-logs",
     "/aws/lambda/myxo-pr-cleanup",
+    retention_in_days=LOG_RETENTION_DAYS,
 )
 
 # --- IAM Role for Lambda execution ------------------------------------------

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -1,0 +1,51 @@
+"""Centralized constants for Myxo Lab infrastructure.
+
+Single source of truth for project-wide values used across infra modules.
+Avoids duplication of cost tags, log retention, port numbers, etc.
+
+Ref: #249
+"""
+
+import pulumi
+
+__all__ = [
+    "COST_TAGS",
+    "LOG_RETENTION_DAYS",
+    "PREVIEW_API_PORT",
+    "PROJECT_NAME",
+    "cost_tags",
+]
+
+# ---------------------------------------------------------------------------
+# Core identifiers
+# ---------------------------------------------------------------------------
+PROJECT_NAME: str = "myxo-lab"
+
+# ---------------------------------------------------------------------------
+# CloudWatch
+# ---------------------------------------------------------------------------
+LOG_RETENTION_DAYS: int = 14
+
+# ---------------------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------------------
+PREVIEW_API_PORT: int = 8080
+
+# ---------------------------------------------------------------------------
+# Cost tags (shared across AWS resources)
+# ---------------------------------------------------------------------------
+COST_TAGS: dict[str, str] = {
+    "Project": PROJECT_NAME,
+    "Environment": pulumi.get_stack(),
+}
+
+
+def cost_tags(*, cost_center: str) -> dict[str, str]:
+    """Return cost tags with a service-specific CostCenter value.
+
+    Parameters
+    ----------
+    cost_center:
+        Value for the ``CostCenter`` tag (e.g. ``"ai-agent"``).
+    """
+    return {**COST_TAGS, "CostCenter": cost_center}

--- a/infra/ecs.py
+++ b/infra/ecs.py
@@ -13,16 +13,13 @@ import json
 import common
 import pulumi
 import pulumi_aws as aws
+from constants import LOG_RETENTION_DAYS, cost_tags
 
 config = pulumi.Config("aws")
 _region = config.require("region")
 
 # --- Cost tags (#137) --------------------------------------------------------
-_COST_TAGS = {
-    "Project": "myxo-lab",
-    "Environment": pulumi.get_stack(),
-    "CostCenter": "ai-agent",
-}
+_COST_TAGS = cost_tags(cost_center="ai-agent")
 
 # --- providers ---------------------------------------------------------------
 ecs = aws.ecs
@@ -31,7 +28,7 @@ iam = aws.iam
 cloudwatch = aws.cloudwatch
 
 # --- CloudWatch Log Group ----------------------------------------------------
-log_group = common.create_log_group("myxo-log-group", "/ecs/myxo")
+log_group = common.create_log_group("myxo-log-group", "/ecs/myxo", retention_in_days=LOG_RETENTION_DAYS)
 
 # --- ECR Repository ----------------------------------------------------------
 repo = ecr.Repository(

--- a/infra/frontend_preview.py
+++ b/infra/frontend_preview.py
@@ -13,7 +13,7 @@ import pulumi_aws as aws
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-config = pulumi.Config("frontend-preview")
+config = pulumi.Config("frontend_preview")
 pr_number = config.get_int("pr_number") or 0
 
 

--- a/infra/frontend_preview.py
+++ b/infra/frontend_preview.py
@@ -13,7 +13,7 @@ import pulumi_aws as aws
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-config = pulumi.Config("frontend_preview")
+config = pulumi.Config("frontend-preview")
 pr_number = config.get_int("pr_number") or 0
 
 

--- a/infra/infisical.py
+++ b/infra/infisical.py
@@ -14,6 +14,7 @@ import common
 import ecs as ecs_infra
 import pulumi
 import pulumi_aws as aws
+from constants import LOG_RETENTION_DAYS, cost_tags
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -34,11 +35,7 @@ ingress_cidr_blocks: list[str] = config.get_object("ingress_cidr_blocks") or [
     vpc_config.require("cidr_block"),
 ]
 
-_COST_TAGS = {
-    "Project": "myxo-lab",
-    "Environment": pulumi.get_stack(),
-    "CostCenter": "secrets-management",
-}
+_COST_TAGS = cost_tags(cost_center="secrets-management")
 
 # ---------------------------------------------------------------------------
 # SSM Parameter Store — secrets for ECS container
@@ -73,6 +70,7 @@ ssm_auth_secret = aws.ssm.Parameter(
 log_group = common.create_log_group(
     "infisical-log-group",
     "/ecs/infisical",
+    retention_in_days=LOG_RETENTION_DAYS,
     tags=_COST_TAGS,
 )
 

--- a/infra/preview.py
+++ b/infra/preview.py
@@ -7,6 +7,7 @@ before merge.  Uses FARGATE_SPOT to keep costs around ~$1/day.
 import ecs
 import pulumi
 import pulumi_aws as aws
+from constants import PREVIEW_API_PORT
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -55,8 +56,8 @@ class PreviewEnvironment:
             ingress=[
                 aws.ec2.SecurityGroupIngressArgs(
                     protocol="tcp",
-                    from_port=8080,
-                    to_port=8080,
+                    from_port=PREVIEW_API_PORT,
+                    to_port=PREVIEW_API_PORT,
                     cidr_blocks=["0.0.0.0/0"],
                     description="API preview port",
                 ),
@@ -95,7 +96,7 @@ class PreviewEnvironment:
 
         # --- Export info -------------------------------------------------------
         # Note: actual URL requires ALB/Cloud Map setup (future work).
-        # For now, access via task public IP on port 8080.
+        # For now, access via task public IP on the preview API port.
         self.service_name = name
 
 

--- a/infra/stale_cleanup.py
+++ b/infra/stale_cleanup.py
@@ -16,6 +16,7 @@ import json
 import common
 import pulumi
 import pulumi_aws as aws
+from constants import LOG_RETENTION_DAYS
 
 # --- IAM Role for Lambda ---------------------------------------------------
 cleanup_role = common.create_lambda_role("myxo-stale-cleanup")
@@ -65,6 +66,7 @@ aws.iam.RolePolicy(
 cleanup_log_group = common.create_log_group(
     "myxo-stale-cleanup-logs",
     "/aws/lambda/myxo-stale-cleanup",
+    retention_in_days=LOG_RETENTION_DAYS,
 )
 
 # --- Lambda Function -------------------------------------------------------

--- a/tests/test_fargate_optimization.py
+++ b/tests/test_fargate_optimization.py
@@ -16,6 +16,10 @@ def _ecs_source() -> str:
     return (INFRA_DIR / "ecs.py").read_text()
 
 
+def _constants_source() -> str:
+    return (INFRA_DIR / "constants.py").read_text()
+
+
 # ---------------------------------------------------------------------------
 # Cost tags (#137)
 # ---------------------------------------------------------------------------
@@ -26,8 +30,12 @@ _REQUIRED_TAG_KEYS = ["Project", "Environment", "CostCenter"]
 def test_cluster_has_cost_tags():
     """ECS Cluster must have Project, Environment, CostCenter tags."""
     src = _ecs_source()
+    constants_src = _constants_source()
+    combined = src + constants_src
     for key in _REQUIRED_TAG_KEYS:
-        assert f'"{key}"' in src, f"Cluster must have {key} tag"
+        has_literal = f'"{key}"' in combined
+        has_ref = "_COST_TAGS" in src or "cost_tags" in src
+        assert has_literal or has_ref, f"Cluster must have {key} tag"
 
 
 def test_task_definition_has_cost_tags():

--- a/tests/test_fargate_optimization.py
+++ b/tests/test_fargate_optimization.py
@@ -30,12 +30,12 @@ _REQUIRED_TAG_KEYS = ["Project", "Environment", "CostCenter"]
 def test_cluster_has_cost_tags():
     """ECS Cluster must have Project, Environment, CostCenter tags."""
     src = _ecs_source()
+    # ecs.py must reference a shared tags dict
+    assert "_COST_TAGS" in src or "cost_tags" in src, "ecs.py must reference cost tags"
+    # constants.py must define the required tag keys
     constants_src = _constants_source()
-    combined = src + constants_src
     for key in _REQUIRED_TAG_KEYS:
-        has_literal = f'"{key}"' in combined
-        has_ref = "_COST_TAGS" in src or "cost_tags" in src
-        assert has_literal or has_ref, f"Cluster must have {key} tag"
+        assert f'"{key}"' in constants_src, f"constants.py must define {key} tag key"
 
 
 def test_task_definition_has_cost_tags():


### PR DESCRIPTION
## Summary
- Create `infra/constants.py` as single source of truth for project-wide values (`PROJECT_NAME`, `COST_TAGS`, `LOG_RETENTION_DAYS`, `PREVIEW_API_PORT`, `cost_tags()` helper)
- Replace all duplicated hardcoded values across `ecs.py`, `infisical.py`, `cleanup.py`, `stale_cleanup.py`, and `preview.py` with constants
- Unify Pulumi Config namespace to kebab-case (`frontend_preview` -> `frontend-preview`)
- Update `test_fargate_optimization.py` to support centralized cost tags pattern

Closes #249

## Test plan
- [x] `uv run ruff check infra/` passes (0 errors)
- [x] `uv run ruff format infra/` — no changes needed
- [x] `uv run pytest tests/ -v` — 380 tests pass