### PR TITLE
refactor: ♻️ parameterize repetitive test cases

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 CONTAINER_DIR = Path(__file__).parent.parent / "container"
 
 
@@ -23,25 +25,13 @@ class TestDevboxJson:
         assert isinstance(data["packages"], list)
         assert len(data["packages"]) > 0
 
-    def test_devbox_json_contains_git(self):
-        data = json.loads(CONTAINER_DIR.joinpath("devbox.json").read_text())
-        pkg_str = " ".join(data["packages"])
-        assert "git" in pkg_str
+    REQUIRED_PACKAGES = ["git", "gh", "python", "nodejs"]
 
-    def test_devbox_json_contains_gh(self):
+    @pytest.mark.parametrize("package", REQUIRED_PACKAGES)
+    def test_devbox_json_contains_package(self, package: str):
         data = json.loads(CONTAINER_DIR.joinpath("devbox.json").read_text())
         pkg_str = " ".join(data["packages"])
-        assert "gh" in pkg_str
-
-    def test_devbox_json_contains_python(self):
-        data = json.loads(CONTAINER_DIR.joinpath("devbox.json").read_text())
-        pkg_str = " ".join(data["packages"])
-        assert "python" in pkg_str
-
-    def test_devbox_json_contains_nodejs(self):
-        data = json.loads(CONTAINER_DIR.joinpath("devbox.json").read_text())
-        pkg_str = " ".join(data["packages"])
-        assert "nodejs" in pkg_str
+        assert package in pkg_str
 
 
 class TestDockerfile:

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -41,18 +42,12 @@ def _get_ecosystem(data: dict, ecosystem: str) -> dict | None:
     return None
 
 
-def test_pip_ecosystem_configured():
-    """pip ecosystem must be configured for Python dependencies."""
+@pytest.mark.parametrize("ecosystem", ["pip", "github-actions"])
+def test_ecosystem_configured(ecosystem: str):
+    """Required ecosystems must be configured."""
     data = yaml.safe_load(DEPENDABOT_PATH.read_text())
-    entry = _get_ecosystem(data, "pip")
-    assert entry is not None, "Missing pip ecosystem configuration"
-
-
-def test_github_actions_ecosystem_configured():
-    """github-actions ecosystem must be configured."""
-    data = yaml.safe_load(DEPENDABOT_PATH.read_text())
-    entry = _get_ecosystem(data, "github-actions")
-    assert entry is not None, "Missing github-actions ecosystem configuration"
+    entry = _get_ecosystem(data, ecosystem)
+    assert entry is not None, f"Missing {ecosystem} ecosystem configuration"
 
 
 def test_target_branch_is_develop():

--- a/tests/test_linter_config.py
+++ b/tests/test_linter_config.py
@@ -3,6 +3,7 @@
 import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -28,33 +29,21 @@ def _hook_ids(data: dict) -> list[str]:
     return ids
 
 
-# ── pre-commit hooks ──
+# ── pre-commit hooks (exact match) ──
+
+EXACT_HOOK_IDS = ["yamllint", "actionlint", "shellcheck", "typos"]
 
 
-def test_precommit_has_yamllint():
+@pytest.mark.parametrize("hook_id", EXACT_HOOK_IDS)
+def test_precommit_has_hook(hook_id: str):
     ids = _hook_ids(_load_precommit())
-    assert "yamllint" in ids
-
-
-def test_precommit_has_actionlint():
-    ids = _hook_ids(_load_precommit())
-    assert "actionlint" in ids
-
-
-def test_precommit_has_shellcheck():
-    ids = _hook_ids(_load_precommit())
-    assert "shellcheck" in ids
+    assert hook_id in ids
 
 
 def test_precommit_has_hadolint():
     ids = _hook_ids(_load_precommit())
     has_hadolint = "hadolint" in ids or "hadolint-docker" in ids
     assert has_hadolint
-
-
-def test_precommit_has_typos():
-    ids = _hook_ids(_load_precommit())
-    assert "typos" in ids
 
 
 def test_precommit_has_markdownlint():
@@ -65,21 +54,17 @@ def test_precommit_has_markdownlint():
 
 # ── config files ──
 
-
-def test_yamllint_config_exists():
-    assert YAMLLINT_PATH.is_file()
-
-
-def test_typos_config_exists():
-    assert TYPOS_PATH.is_file()
-
-
-def test_markdownlint_config_exists():
-    assert MARKDOWNLINT_PATH.is_file()
+CONFIG_FILES = [
+    pytest.param(YAMLLINT_PATH, id="yamllint"),
+    pytest.param(TYPOS_PATH, id="typos"),
+    pytest.param(MARKDOWNLINT_PATH, id="markdownlint"),
+    pytest.param(HADOLINT_PATH, id="hadolint"),
+]
 
 
-def test_hadolint_config_exists():
-    assert HADOLINT_PATH.is_file()
+@pytest.mark.parametrize("config_path", CONFIG_FILES)
+def test_config_file_exists(config_path: Path):
+    assert config_path.is_file()
 
 
 # ── CI workflows ──

--- a/tests/test_pr_title_lint.py
+++ b/tests/test_pr_title_lint.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT = Path(__file__).parent.parent / ".github" / "scripts" / "pr-title-lint.py"
 
 
@@ -15,66 +17,33 @@ def _run(title: str) -> subprocess.CompletedProcess:
     )
 
 
-def test_valid_feat_title():
-    result = _run("feat: ✨ add hypothesis tracking endpoint")
+VALID_TITLES = [
+    pytest.param("feat: ✨ add hypothesis tracking endpoint", id="feat"),
+    pytest.param("fix: 🐛 resolve scheduling race condition", id="fix"),
+    pytest.param("chore: 🔧 add PR title validation", id="chore"),
+    pytest.param("test: ✅ add myxo execution tests", id="test"),
+    pytest.param("docs: 📝 update architecture diagram", id="docs"),
+    pytest.param("refactor: ♻️ extract experiment validation logic", id="refactor"),
+    pytest.param("feat: ✨ a", id="min-length-subject"),
+]
+
+INVALID_TITLES = [
+    pytest.param("feat: add something", id="missing-emoji"),
+    pytest.param("✨ add something", id="missing-type"),
+    pytest.param("feat: ✨ Add something", id="uppercase-subject"),
+    pytest.param("feat: ✨ add something.", id="trailing-period"),
+    pytest.param("feat: ✨ " + "a" * 70, id="too-long"),
+    pytest.param("", id="empty"),
+]
+
+
+@pytest.mark.parametrize("title", VALID_TITLES)
+def test_valid_title(title: str):
+    result = _run(title)
     assert result.returncode == 0
 
 
-def test_valid_fix_title():
-    result = _run("fix: 🐛 resolve scheduling race condition")
-    assert result.returncode == 0
-
-
-def test_valid_chore_title():
-    result = _run("chore: 🔧 add PR title validation")
-    assert result.returncode == 0
-
-
-def test_valid_test_title():
-    result = _run("test: ✅ add myxo execution tests")
-    assert result.returncode == 0
-
-
-def test_valid_docs_title():
-    result = _run("docs: 📝 update architecture diagram")
-    assert result.returncode == 0
-
-
-def test_valid_refactor_title():
-    result = _run("refactor: ♻️ extract experiment validation logic")
-    assert result.returncode == 0
-
-
-def test_valid_min_length_subject():
-    result = _run("feat: ✨ a")
-    assert result.returncode == 0
-
-
-def test_reject_missing_emoji():
-    result = _run("feat: add something")
-    assert result.returncode == 1
-
-
-def test_reject_missing_type():
-    result = _run("✨ add something")
-    assert result.returncode == 1
-
-
-def test_reject_uppercase_subject():
-    result = _run("feat: ✨ Add something")
-    assert result.returncode == 1
-
-
-def test_reject_trailing_period():
-    result = _run("feat: ✨ add something.")
-    assert result.returncode == 1
-
-
-def test_reject_too_long():
-    result = _run("feat: ✨ " + "a" * 70)
-    assert result.returncode == 1
-
-
-def test_reject_empty():
-    result = _run("")
+@pytest.mark.parametrize("title", INVALID_TITLES)
+def test_reject_invalid_title(title: str):
+    result = _run(title)
     assert result.returncode == 1

--- a/tests/test_shared_workflows.py
+++ b/tests/test_shared_workflows.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from helpers import get_on_block, is_sha_pinned, load_workflow
 
 REUSABLE_CI_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "reusable-python-ci.yml"
@@ -29,60 +30,44 @@ def test_has_workflow_call_trigger():
     assert "workflow_call" in on_block, "Must have workflow_call trigger"
 
 
-def test_workflow_call_has_python_version_input():
+WORKFLOW_CALL_INPUTS = [
+    pytest.param("python_version", "3.13", id="python_version"),
+    pytest.param("run_tests", True, id="run_tests"),
+    pytest.param("run_lint", True, id="run_lint"),
+]
+
+
+@pytest.mark.parametrize("input_name,expected_default", WORKFLOW_CALL_INPUTS)
+def test_workflow_call_has_input(input_name: str, expected_default):
     data = load_workflow(REUSABLE_CI_PATH)
     on_block = get_on_block(data)
     inputs = on_block["workflow_call"].get("inputs", {})
-    pv = inputs.get("python_version", {})
-    assert pv, "Must define python_version input"
-    assert pv.get("default") == "3.13", "python_version default must be '3.13'"
-
-
-def test_workflow_call_has_run_tests_input():
-    data = load_workflow(REUSABLE_CI_PATH)
-    on_block = get_on_block(data)
-    inputs = on_block["workflow_call"].get("inputs", {})
-    rt = inputs.get("run_tests", {})
-    assert rt, "Must define run_tests input"
-    assert rt.get("default") is True, "run_tests default must be true"
-
-
-def test_workflow_call_has_run_lint_input():
-    data = load_workflow(REUSABLE_CI_PATH)
-    on_block = get_on_block(data)
-    inputs = on_block["workflow_call"].get("inputs", {})
-    rl = inputs.get("run_lint", {})
-    assert rl, "Must define run_lint input"
-    assert rl.get("default") is True, "run_lint default must be true"
+    entry = inputs.get(input_name, {})
+    assert entry, f"Must define {input_name} input"
+    assert entry.get("default") == expected_default, f"{input_name} default must be {expected_default!r}"
 
 
 # ── jobs ──
 
+REQUIRED_JOBS = ["lint", "test"]
 
-def test_defines_lint_job():
+
+@pytest.mark.parametrize("job_name", REQUIRED_JOBS)
+def test_defines_job(job_name: str):
     data = load_workflow(REUSABLE_CI_PATH)
     jobs = data.get("jobs", {})
-    assert "lint" in jobs, "Must define lint job"
+    assert job_name in jobs, f"Must define {job_name} job"
 
 
-def test_defines_test_job():
-    data = load_workflow(REUSABLE_CI_PATH)
-    jobs = data.get("jobs", {})
-    assert "test" in jobs, "Must define test job"
+RUFF_COMMANDS = ["ruff check", "ruff format"]
 
 
-def test_lint_job_runs_ruff_check():
+@pytest.mark.parametrize("ruff_cmd", RUFF_COMMANDS)
+def test_lint_job_runs_ruff_command(ruff_cmd: str):
     data = load_workflow(REUSABLE_CI_PATH)
     lint_steps = data["jobs"]["lint"].get("steps", [])
     run_cmds = [s["run"] for s in lint_steps if "run" in s]
-    assert any("ruff check" in cmd for cmd in run_cmds), "lint job must run ruff check"
-
-
-def test_lint_job_runs_ruff_format():
-    data = load_workflow(REUSABLE_CI_PATH)
-    lint_steps = data["jobs"]["lint"].get("steps", [])
-    run_cmds = [s["run"] for s in lint_steps if "run" in s]
-    assert any("ruff format" in cmd for cmd in run_cmds), "lint job must run ruff format"
+    assert any(ruff_cmd in cmd for cmd in run_cmds), f"lint job must run {ruff_cmd}"
 
 
 def test_test_job_runs_pytest_with_markers():
@@ -96,29 +81,23 @@ def test_test_job_runs_pytest_with_markers():
 
 # ── actions versions ──
 
+SHA_PINNED_ACTIONS = [
+    pytest.param("actions/checkout", id="checkout"),
+    pytest.param("setup-uv", id="setup-uv"),
+]
 
-def test_uses_actions_checkout_sha_pinned():
+
+@pytest.mark.parametrize("action_name", SHA_PINNED_ACTIONS)
+def test_action_is_sha_pinned(action_name: str):
     data = load_workflow(REUSABLE_CI_PATH)
-    checkout_found = False
+    found = False
     for job in data.get("jobs", {}).values():
         for step in job.get("steps", []):
             uses = step.get("uses", "")
-            if "actions/checkout" in uses:
-                assert is_sha_pinned(uses), f"actions/checkout must be SHA-pinned, got: {uses}"
-                checkout_found = True
-    assert checkout_found, "Must use actions/checkout"
-
-
-def test_uses_setup_uv_sha_pinned():
-    data = load_workflow(REUSABLE_CI_PATH)
-    uv_found = False
-    for job in data.get("jobs", {}).values():
-        for step in job.get("steps", []):
-            uses = step.get("uses", "")
-            if "setup-uv" in uses:
-                assert is_sha_pinned(uses), f"astral-sh/setup-uv must be SHA-pinned, got: {uses}"
-                uv_found = True
-    assert uv_found, "Must use astral-sh/setup-uv"
+            if action_name in uses:
+                assert is_sha_pinned(uses), f"{action_name} must be SHA-pinned, got: {uses}"
+                found = True
+    assert found, f"Must use {action_name}"
 
 
 def test_setup_uv_enables_cache():

--- a/tests/test_shared_workflows.py
+++ b/tests/test_shared_workflows.py
@@ -83,7 +83,7 @@ def test_test_job_runs_pytest_with_markers():
 
 SHA_PINNED_ACTIONS = [
     pytest.param("actions/checkout", id="checkout"),
-    pytest.param("setup-uv", id="setup-uv"),
+    pytest.param("astral-sh/setup-uv", id="setup-uv"),
 ]
 
 

--- a/tests/test_terminology.py
+++ b/tests/test_terminology.py
@@ -57,23 +57,14 @@ class TestDeprecatedAgentNames:
 class TestNewAgentNames:
     """Ensure the new 4-layer model agent names are present."""
 
-    @pytest.mark.small
-    def test_readme_has_microscope_role(self):
-        """Microscope should appear as a role in README."""
-        content = (ROOT / "README.md").read_text(encoding="utf-8")
-        assert "**Microscope**" in content
+    REQUIRED_ROLES = ["Microscope", "Recorder", "Fellow"]
 
     @pytest.mark.small
-    def test_readme_has_recorder_role(self):
-        """Recorder should appear as a role in README."""
+    @pytest.mark.parametrize("role", REQUIRED_ROLES)
+    def test_readme_has_role(self, role: str):
+        """Required role should appear as bold text in README."""
         content = (ROOT / "README.md").read_text(encoding="utf-8")
-        assert "**Recorder**" in content
-
-    @pytest.mark.small
-    def test_readme_has_fellow_role(self):
-        """Fellow should appear as a role in README."""
-        content = (ROOT / "README.md").read_text(encoding="utf-8")
-        assert "**Fellow**" in content
+        assert f"**{role}**" in content
 
     @pytest.mark.small
     def test_readme_protocol_still_exists_as_artifact(self):
@@ -88,26 +79,13 @@ class TestNewAgentNames:
 class TestFourLayerModel:
     """Ensure the 4-layer model is documented in README."""
 
-    @pytest.mark.small
-    def test_readme_has_person_layer(self):
-        content = (ROOT / "README.md").read_text(encoding="utf-8")
-        assert "Person" in content
+    LAYERS = ["Person", "Device", "Artifact", "Environment"]
 
     @pytest.mark.small
-    def test_readme_has_device_layer(self):
+    @pytest.mark.parametrize("layer", LAYERS)
+    def test_readme_has_layer(self, layer: str):
         content = (ROOT / "README.md").read_text(encoding="utf-8")
-        assert "Device" in content
-
-    @pytest.mark.small
-    def test_readme_has_artifact_layer(self):
-        content = (ROOT / "README.md").read_text(encoding="utf-8")
-        assert "Artifact" in content
-
-    @pytest.mark.small
-    def test_readme_has_environment_layer(self):
-        content = (ROOT / "README.md").read_text(encoding="utf-8")
-        # "Environment" already in the section header
-        assert "Environment" in content
+        assert layer in content
 
 
 # --- Mermaid diagram ---
@@ -138,17 +116,14 @@ class TestMermaidDiagram:
 class TestSkillDocsUpdated:
     """Ensure skill docs use new terminology."""
 
-    @pytest.mark.small
-    def test_pr_rules_uses_fellow(self):
-        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text(encoding="utf-8")
-        assert "Fellow" in content
+    SKILL_TERM_CASES = [
+        pytest.param("pr-rules", "Fellow", id="pr-rules-fellow"),
+        pytest.param("pr-rules", "Microscope", id="pr-rules-microscope"),
+        pytest.param("commit-rules", "Fellow", id="commit-rules-fellow"),
+    ]
 
     @pytest.mark.small
-    def test_pr_rules_uses_microscope(self):
-        content = (ROOT / ".claude" / "skills" / "pr-rules" / "SKILL.md").read_text(encoding="utf-8")
-        assert "Microscope" in content
-
-    @pytest.mark.small
-    def test_commit_rules_uses_fellow(self):
-        content = (ROOT / ".claude" / "skills" / "commit-rules" / "SKILL.md").read_text(encoding="utf-8")
-        assert "Fellow" in content
+    @pytest.mark.parametrize("skill,term", SKILL_TERM_CASES)
+    def test_skill_doc_uses_term(self, skill: str, term: str):
+        content = (ROOT / ".claude" / "skills" / skill / "SKILL.md").read_text(encoding="utf-8")
+        assert term in content

--- a/tests/test_workflow_procedure.py
+++ b/tests/test_workflow_procedure.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOW = Path(__file__).parent.parent / ".github" / "workflows" / "myxo-procedure.yml"
@@ -24,24 +25,13 @@ def test_triggers_on_issues_labeled():
     assert "labeled" in issues_config.get("types", []), "Workflow should trigger on labeled type"
 
 
-def test_references_myxo_ready_label():
+MYXO_LABELS = ["myxo-ready", "myxo-active", "myxo-complete", "myxo-abort"]
+
+
+@pytest.mark.parametrize("label", MYXO_LABELS)
+def test_references_myxo_label(label: str):
     content = WORKFLOW.read_text()
-    assert "state: myxo-ready" in content, "Workflow should reference the myxo-ready label"
-
-
-def test_references_myxo_active_label():
-    content = WORKFLOW.read_text()
-    assert "state: myxo-active" in content, "Workflow should reference the myxo-active label"
-
-
-def test_references_myxo_complete_label():
-    content = WORKFLOW.read_text()
-    assert "state: myxo-complete" in content, "Workflow should reference the myxo-complete label"
-
-
-def test_references_myxo_abort_label():
-    content = WORKFLOW.read_text()
-    assert "state: myxo-abort" in content, "Workflow should reference the myxo-abort label"
+    assert f"state: {label}" in content, f"Workflow should reference the {label} label"
 
 
 def test_uses_env_for_issue_data():


### PR DESCRIPTION
## Summary
- Replace repetitive individual test functions with @pytest.mark.parametrize across 7 test files
- Reduce test boilerplate by ~117 lines (108 insertions, 225 deletions) while preserving all 380 test cases
- Files refactored: test_container.py, test_dependabot.py, test_pr_title_lint.py, test_linter_config.py, test_workflow_procedure.py, test_terminology.py, test_shared_workflows.py

Closes #253

## Test plan
- [x] uv run pytest tests/ -v passes with all 380 tests
- [x] uv run ruff check tests/ passes
- [x] uv run ruff format tests/ produces no changes