### PR TITLE
refactor: ♻️ extract common Pulumi infrastructure components

### DIFF
--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -3,6 +3,7 @@
 import secrets
 
 import cleanup
+import common
 import ecs
 import frontend_preview
 import github_app
@@ -16,6 +17,7 @@ import stale_cleanup
 # Pulumi registers resources on import — list modules explicitly for ruff F401
 __all__ = [
     "cleanup",
+    "common",
     "ecs",
     "frontend_preview",
     "github_app",

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -14,7 +14,7 @@ import pulumi
 import pulumi_github as github
 import stale_cleanup
 
-# Pulumi registers resources on import — list modules explicitly for ruff F401
+# List all infra modules for ruff F401 — resource modules register on import
 __all__ = [
     "cleanup",
     "common",

--- a/infra/cleanup.py
+++ b/infra/cleanup.py
@@ -10,6 +10,7 @@ when a pull request is closed:
 
 import json
 
+import common
 import pulumi
 import pulumi_aws as aws
 
@@ -17,36 +18,16 @@ iam = aws.iam
 cloudwatch = aws.cloudwatch
 
 # --- CloudWatch Log Group for Lambda ----------------------------------------
-cleanup_log_group = cloudwatch.LogGroup(
+cleanup_log_group = common.create_log_group(
     "myxo-pr-cleanup-logs",
-    name="/aws/lambda/myxo-pr-cleanup",
-    retention_in_days=14,
+    "/aws/lambda/myxo-pr-cleanup",
 )
 
 # --- IAM Role for Lambda execution ------------------------------------------
-cleanup_role = iam.Role(
-    "myxo-pr-cleanup-role",
-    name="myxo-pr-cleanup-role",
-    assume_role_policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "lambda.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-    ),
-)
+cleanup_role = common.create_lambda_role("myxo-pr-cleanup")
 
 # CloudWatch Logs permissions
-iam.RolePolicyAttachment(
-    "myxo-pr-cleanup-logs-policy",
-    role=cleanup_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
+common.attach_basic_execution_role("myxo-pr-cleanup", cleanup_role)
 
 # ECS task stop permissions
 iam.RolePolicy(
@@ -104,13 +85,7 @@ cloudwatch.EventTarget(
 )
 
 # Allow EventBridge to invoke the Lambda
-aws.lambda_.Permission(
-    "myxo-pr-cleanup-eventbridge-permission",
-    action="lambda:InvokeFunction",
-    function=cleanup_lambda.name,
-    principal="events.amazonaws.com",
-    source_arn=pr_close_rule.arn,
-)
+common.create_eventbridge_lambda_permission("myxo-pr-cleanup", cleanup_lambda, pr_close_rule)
 
 # --- Exports ----------------------------------------------------------------
 pulumi.export("cleanup_lambda_arn", cleanup_lambda.arn)

--- a/infra/common.py
+++ b/infra/common.py
@@ -57,15 +57,15 @@ def create_lambda_role(name: str) -> aws.iam.Role:
 
 
 def create_log_group(
-    name: str,
-    path: str,
+    resource_name: str,
+    log_group_path: str,
     retention_in_days: int = 14,
     **kwargs: object,
 ) -> aws.cloudwatch.LogGroup:
     """Create a CloudWatch Log Group with standard retention."""
     return aws.cloudwatch.LogGroup(
-        name,
-        name=path,
+        resource_name,
+        name=log_group_path,
         retention_in_days=retention_in_days,
         **kwargs,
     )

--- a/infra/common.py
+++ b/infra/common.py
@@ -1,0 +1,95 @@
+"""Shared infrastructure helpers to reduce duplication across modules.
+
+Provides reusable factory functions for common AWS resource patterns:
+- IAM Lambda roles with assume-role policies
+- CloudWatch Log Groups with standard retention
+- Lambda BasicExecutionRole policy attachments
+- EventBridge → Lambda invocation permissions
+"""
+
+import json
+
+import pulumi_aws as aws
+
+__all__ = [
+    "LAMBDA_ASSUME_ROLE_POLICY",
+    "ECS_TASK_ASSUME_ROLE_POLICY",
+    "create_lambda_role",
+    "create_log_group",
+    "attach_basic_execution_role",
+    "create_eventbridge_lambda_permission",
+]
+
+LAMBDA_ASSUME_ROLE_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "lambda.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+)
+
+ECS_TASK_ASSUME_ROLE_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+)
+
+
+def create_lambda_role(name: str) -> aws.iam.Role:
+    """Create an IAM Role with Lambda assume-role policy."""
+    return aws.iam.Role(
+        f"{name}-role",
+        name=f"{name}-role",
+        assume_role_policy=LAMBDA_ASSUME_ROLE_POLICY,
+    )
+
+
+def create_log_group(
+    name: str,
+    path: str,
+    retention_in_days: int = 14,
+    **kwargs: object,
+) -> aws.cloudwatch.LogGroup:
+    """Create a CloudWatch Log Group with standard retention."""
+    return aws.cloudwatch.LogGroup(
+        name,
+        name=path,
+        retention_in_days=retention_in_days,
+        **kwargs,
+    )
+
+
+def attach_basic_execution_role(name: str, role: aws.iam.Role) -> aws.iam.RolePolicyAttachment:
+    """Attach AWSLambdaBasicExecutionRole policy to a role."""
+    return aws.iam.RolePolicyAttachment(
+        f"{name}-basic-exec",
+        role=role.name,
+        policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+    )
+
+
+def create_eventbridge_lambda_permission(
+    name: str,
+    function: aws.lambda_.Function,
+    rule: aws.cloudwatch.EventRule,
+) -> aws.lambda_.Permission:
+    """Allow EventBridge to invoke a Lambda function."""
+    return aws.lambda_.Permission(
+        f"{name}-eventbridge-permission",
+        action="lambda:InvokeFunction",
+        function=function.name,
+        principal="events.amazonaws.com",
+        source_arn=rule.arn,
+    )

--- a/infra/ecs.py
+++ b/infra/ecs.py
@@ -10,6 +10,7 @@ Defines minimal ECS infrastructure:
 
 import json
 
+import common
 import pulumi
 import pulumi_aws as aws
 
@@ -30,11 +31,7 @@ iam = aws.iam
 cloudwatch = aws.cloudwatch
 
 # --- CloudWatch Log Group ----------------------------------------------------
-log_group = cloudwatch.LogGroup(
-    "myxo-log-group",
-    name="/ecs/myxo",
-    retention_in_days=14,
-)
+log_group = common.create_log_group("myxo-log-group", "/ecs/myxo")
 
 # --- ECR Repository ----------------------------------------------------------
 repo = ecr.Repository(
@@ -59,18 +56,7 @@ cluster = ecs.Cluster(
 task_execution_role = iam.Role(
     "myxo-task-execution-role",
     name="myxo-task-execution-role",
-    assume_role_policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-    ),
+    assume_role_policy=common.ECS_TASK_ASSUME_ROLE_POLICY,
 )
 
 iam.RolePolicyAttachment(
@@ -83,18 +69,7 @@ iam.RolePolicyAttachment(
 task_role = iam.Role(
     "myxo-task-role",
     name="myxo-task-role",
-    assume_role_policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-    ),
+    assume_role_policy=common.ECS_TASK_ASSUME_ROLE_POLICY,
 )
 
 # EFS client permissions for task role

--- a/infra/infisical.py
+++ b/infra/infisical.py
@@ -10,6 +10,7 @@ Ref: https://infisical.com/docs/self-hosting/deployments/aws
 
 import json
 
+import common
 import ecs as ecs_infra
 import pulumi
 import pulumi_aws as aws
@@ -69,10 +70,9 @@ ssm_auth_secret = aws.ssm.Parameter(
 # ---------------------------------------------------------------------------
 # CloudWatch Log Group
 # ---------------------------------------------------------------------------
-log_group = aws.cloudwatch.LogGroup(
+log_group = common.create_log_group(
     "infisical-log-group",
-    name="/ecs/infisical",
-    retention_in_days=14,
+    "/ecs/infisical",
     tags=_COST_TAGS,
 )
 

--- a/infra/stale_cleanup.py
+++ b/infra/stale_cleanup.py
@@ -13,33 +13,15 @@ Resources:
 
 import json
 
+import common
 import pulumi
 import pulumi_aws as aws
 
 # --- IAM Role for Lambda ---------------------------------------------------
-cleanup_role = aws.iam.Role(
-    "myxo-stale-cleanup-role",
-    name="myxo-stale-cleanup-role",
-    assume_role_policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "lambda.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-    ),
-)
+cleanup_role = common.create_lambda_role("myxo-stale-cleanup")
 
 # Basic Lambda execution (CloudWatch Logs)
-aws.iam.RolePolicyAttachment(
-    "myxo-stale-cleanup-basic-exec",
-    role=cleanup_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-)
+common.attach_basic_execution_role("myxo-stale-cleanup", cleanup_role)
 
 # Inline policy for ECS + EC2 describe/delete with AutoDelete tag
 aws.iam.RolePolicy(
@@ -80,10 +62,9 @@ aws.iam.RolePolicy(
 )
 
 # --- CloudWatch Log Group --------------------------------------------------
-cleanup_log_group = aws.cloudwatch.LogGroup(
+cleanup_log_group = common.create_log_group(
     "myxo-stale-cleanup-logs",
-    name="/aws/lambda/myxo-stale-cleanup",
-    retention_in_days=14,
+    "/aws/lambda/myxo-stale-cleanup",
 )
 
 # --- Lambda Function -------------------------------------------------------
@@ -114,13 +95,7 @@ aws.cloudwatch.EventTarget(
 )
 
 # --- Lambda Permission for EventBridge ------------------------------------
-aws.lambda_.Permission(
-    "myxo-stale-cleanup-invoke",
-    action="lambda:InvokeFunction",
-    function=cleanup_function.name,
-    principal="events.amazonaws.com",
-    source_arn=schedule_rule.arn,
-)
+common.create_eventbridge_lambda_permission("myxo-stale-cleanup", cleanup_function, schedule_rule)
 
 # --- Exports ---------------------------------------------------------------
 pulumi.export("stale_cleanup_function_arn", cleanup_function.arn)

--- a/tests/test_cleanup_infra.py
+++ b/tests/test_cleanup_infra.py
@@ -38,13 +38,14 @@ def test_defines_lambda_function():
 def test_defines_iam_role():
     """cleanup.py must define an IAM Role for Lambda execution."""
     src = _cleanup_source()
-    assert "iam.Role(" in src, "cleanup.py must define iam.Role"
+    assert "iam.Role(" in src or "common.create_lambda_role(" in src, "cleanup.py must define iam.Role"
 
 
 def test_defines_cloudwatch_log_group():
     """cleanup.py must define a CloudWatch Log Group for Lambda logs."""
     src = _cleanup_source()
-    assert "cloudwatch.LogGroup(" in src, "cleanup.py must define cloudwatch.LogGroup"
+    has_log_group = "cloudwatch.LogGroup(" in src or "common.create_log_group(" in src
+    assert has_log_group, "cleanup.py must define cloudwatch.LogGroup"
 
 
 def test_defines_eventbridge_rule():

--- a/tests/test_ecs_infra.py
+++ b/tests/test_ecs_infra.py
@@ -45,7 +45,7 @@ def test_defines_task_definition():
 def test_defines_iam_roles():
     """ecs.py must define IAM roles for task execution and task."""
     src = _ecs_source()
-    assert "iam.Role(" in src, "ecs.py must define iam.Role"
+    assert "iam.Role(" in src or "common.ECS_TASK_ASSUME_ROLE_POLICY" in src, "ecs.py must define iam.Role"
     assert "task_execution_role" in src or "task-execution-role" in src
     assert "task_role" in src or "task-role" in src
 
@@ -53,7 +53,7 @@ def test_defines_iam_roles():
 def test_defines_cloudwatch_log_group():
     """ecs.py must define a CloudWatch Log Group."""
     src = _ecs_source()
-    assert "cloudwatch.LogGroup(" in src, "ecs.py must define cloudwatch.LogGroup"
+    assert "cloudwatch.LogGroup(" in src or "common.create_log_group(" in src, "ecs.py must define cloudwatch.LogGroup"
 
 
 def test_no_pseudopod_references():

--- a/tests/test_ecs_infra.py
+++ b/tests/test_ecs_infra.py
@@ -45,7 +45,7 @@ def test_defines_task_definition():
 def test_defines_iam_roles():
     """ecs.py must define IAM roles for task execution and task."""
     src = _ecs_source()
-    assert "iam.Role(" in src or "common.ECS_TASK_ASSUME_ROLE_POLICY" in src, "ecs.py must define iam.Role"
+    assert "iam.Role(" in src, "ecs.py must define iam.Role"
     assert "task_execution_role" in src or "task-execution-role" in src
     assert "task_role" in src or "task-role" in src
 

--- a/tests/test_stale_cleanup_infra.py
+++ b/tests/test_stale_cleanup_infra.py
@@ -50,13 +50,14 @@ def test_defines_eventbridge_target():
 def test_defines_iam_role():
     """stale_cleanup.py must define an IAM role for the Lambda function."""
     src = _stale_cleanup_source()
-    assert "iam.Role(" in src, "stale_cleanup.py must define iam.Role"
+    assert "iam.Role(" in src or "common.create_lambda_role(" in src, "stale_cleanup.py must define iam.Role"
 
 
 def test_defines_cloudwatch_log_group():
     """stale_cleanup.py must define a CloudWatch Log Group for Lambda logs."""
     src = _stale_cleanup_source()
-    assert "cloudwatch.LogGroup(" in src, "stale_cleanup.py must define cloudwatch.LogGroup"
+    has_log_group = "cloudwatch.LogGroup(" in src or "common.create_log_group(" in src
+    assert has_log_group, "stale_cleanup.py must define cloudwatch.LogGroup"
 
 
 def test_myxo_naming():


### PR DESCRIPTION
## Summary

- Create `infra/common.py` with shared helper functions to eliminate duplicated infrastructure patterns
- Extract `create_lambda_role`, `create_log_group`, `attach_basic_execution_role`, `create_eventbridge_lambda_permission`
- Add `LAMBDA_ASSUME_ROLE_POLICY` and `ECS_TASK_ASSUME_ROLE_POLICY` constants
- Replace duplicated code in `cleanup.py`, `stale_cleanup.py`, `ecs.py`, `infisical.py`
- Update source-level tests to accept both direct and helper-based resource definitions

Closes #248

## Test plan

- [x] All 380 tests pass
- [x] ruff check and format pass
- [ ] CI passes (lint, test, trivy)