### PR TITLE
refactor: ♻️ standardize resource tagging strategy

### DIFF
--- a/.github/scripts/pr-title-lint.py
+++ b/.github/scripts/pr-title-lint.py
@@ -36,7 +36,7 @@ def validate(title: str) -> str | None:
     if len(title) > MAX_LENGTH:
         return f"Title exceeds {MAX_LENGTH} characters ({len(title)})"
     if not TITLE_RE.match(title):
-        return f"Title does not match format: <type>: <emoji> <subject>"
+        return "Title does not match format: <type>: <emoji> <subject>"
     return None
 
 
@@ -50,7 +50,7 @@ def main() -> int:
     if error:
         print(f"❌ {error}", file=sys.stderr)
         print(f"   Got: {title!r}", file=sys.stderr)
-        print(f"   Expected: <type>: <emoji> <subject>", file=sys.stderr)
+        print("   Expected: <type>: <emoji> <subject>", file=sys.stderr)
         return 1
 
     print(f"✅ Title OK: {title}")

--- a/tests/test_resource_tagging.py
+++ b/tests/test_resource_tagging.py
@@ -89,7 +89,6 @@ class TestPreviewTags:
     def test_service_has_tags(self):
         """ECS Service tags must include cost tags (via _tags variable)."""
         src = _read_source("preview.py")
-        # Service should use tags derived from preview_tags
         assert "tags=_tags" in src or "tags={" in src
 
 
@@ -113,7 +112,6 @@ class TestFrontendPreviewTags:
     def test_distribution_has_tags(self):
         """CloudFront Distribution tags must include cost tags."""
         src = _read_source("frontend_preview.py")
-        # Both bucket and distribution should use _tags derived from preview_tags
         assert src.count("**_tags") >= 2
 
 
@@ -132,7 +130,6 @@ class TestCleanupTags:
 
     def test_lambda_has_tags(self):
         src = _read_source("cleanup.py")
-        # Lambda function should have tags= argument
         assert "tags=" in src
 
 
@@ -152,7 +149,6 @@ class TestStaleCleanupTags:
     def test_lambda_has_tags(self):
         src = _read_source("stale_cleanup.py")
         lines = src.split("\n")
-        # Find the Lambda Function resource and check it has tags
         in_lambda = False
         has_tags = False
         for line in lines:

--- a/tests/test_resource_tagging.py
+++ b/tests/test_resource_tagging.py
@@ -173,9 +173,7 @@ class TestPreviewTags:
     def test_service_has_tags(self):
         """ECS Service must have tags= keyword argument."""
         src = _read_source("preview.py")
-        assert _find_keyword_call(src, "Service", "tags"), (
-            "preview.py ECS Service must have tags= argument"
-        )
+        assert _find_keyword_call(src, "Service", "tags"), "preview.py ECS Service must have tags= argument"
 
 
 # ===========================================================================
@@ -218,9 +216,7 @@ class TestCleanupTags:
 
     def test_lambda_has_tags(self):
         src = _read_source("cleanup.py")
-        assert _find_keyword_call(src, "Function", "tags"), (
-            "cleanup.py Lambda Function must have tags= argument"
-        )
+        assert _find_keyword_call(src, "Function", "tags"), "cleanup.py Lambda Function must have tags= argument"
 
 
 # ===========================================================================
@@ -238,6 +234,4 @@ class TestStaleCleanupTags:
 
     def test_lambda_has_tags(self):
         src = _read_source("stale_cleanup.py")
-        assert _find_keyword_call(src, "Function", "tags"), (
-            "stale_cleanup.py Lambda Function must have tags= argument"
-        )
+        assert _find_keyword_call(src, "Function", "tags"), "stale_cleanup.py Lambda Function must have tags= argument"

--- a/tests/test_resource_tagging.py
+++ b/tests/test_resource_tagging.py
@@ -8,6 +8,7 @@ Verifies:
 - Cleanup modules reference the correct AutoDelete tag key from constants
 """
 
+import ast
 from pathlib import Path
 
 INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
@@ -19,11 +20,77 @@ INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
 
 
 def _read_source(filename: str) -> str:
-    return (INFRA_DIR / filename).read_text()
+    return (INFRA_DIR / filename).read_text(encoding="utf-8")
+
+
+def _parse_module(filename: str) -> ast.Module:
+    return ast.parse(_read_source(filename))
+
+
+def _get_dict_keys(node: ast.Dict) -> list[str]:
+    """Extract string keys from an ast.Dict node."""
+    return [k.value for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)]
+
+
+def _find_assignment_dict(tree: ast.Module, name: str) -> ast.Dict | None:
+    """Find a top-level assignment like `NAME = {...}` and return the Dict node.
+
+    Handles both plain assignment (ast.Assign) and annotated assignment (ast.AnnAssign).
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name and isinstance(node.value, ast.Dict):
+                    return node.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+            and node.value is not None
+            and isinstance(node.value, ast.Dict)
+        ):
+            return node.value
+    return None
+
+
+def _find_function_def(tree: ast.Module, name: str) -> ast.FunctionDef | None:
+    """Find a top-level function definition by name."""
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _find_all_list(tree: ast.Module) -> list[str]:
+    """Extract entries from __all__ = [...]."""
+    # __all__ is a List, not a Dict — walk the tree directly
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__" and isinstance(node.value, ast.List):
+                    return [
+                        elt.value
+                        for elt in node.value.elts
+                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                    ]
+    return []
+
+
+def _find_keyword_call(src: str, func_name: str, keyword: str) -> bool:
+    """Check if a function/constructor call includes a specific keyword argument."""
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func_str = ast.unparse(node.func)
+            if func_name in func_str:
+                for kw in node.keywords:
+                    if kw.arg == keyword:
+                        return True
+    return False
 
 
 # ===========================================================================
-# 1. constants.py — required tag keys & helper functions
+# 1. constants.py — required tag keys & helper functions (ast-based)
 # ===========================================================================
 
 
@@ -31,41 +98,58 @@ class TestConstantsRequiredTags:
     """COST_TAGS and cost_tags() must include all mandatory keys."""
 
     def test_cost_tags_dict_has_project(self):
-        src = _read_source("constants.py")
-        assert '"Project"' in src
+        tree = _parse_module("constants.py")
+        cost_dict = _find_assignment_dict(tree, "COST_TAGS")
+        assert cost_dict is not None, "COST_TAGS dict must exist"
+        assert "Project" in _get_dict_keys(cost_dict)
 
     def test_cost_tags_dict_has_environment(self):
-        src = _read_source("constants.py")
-        assert '"Environment"' in src
+        tree = _parse_module("constants.py")
+        cost_dict = _find_assignment_dict(tree, "COST_TAGS")
+        assert cost_dict is not None
+        assert "Environment" in _get_dict_keys(cost_dict)
 
     def test_cost_tags_dict_has_managed_by(self):
         """ManagedBy tag must be in COST_TAGS base dict."""
-        src = _read_source("constants.py")
-        assert '"ManagedBy"' in src
+        tree = _parse_module("constants.py")
+        cost_dict = _find_assignment_dict(tree, "COST_TAGS")
+        assert cost_dict is not None
+        assert "ManagedBy" in _get_dict_keys(cost_dict)
 
     def test_cost_tags_function_adds_cost_center(self):
-        src = _read_source("constants.py")
-        assert '"CostCenter"' in src
+        tree = _parse_module("constants.py")
+        func = _find_function_def(tree, "cost_tags")
+        assert func is not None, "cost_tags() function must exist"
+        func_src = ast.unparse(func)
+        assert "CostCenter" in func_src
 
     def test_preview_tags_function_exists(self):
         """preview_tags() helper must be defined for ephemeral resources."""
-        src = _read_source("constants.py")
-        assert "def preview_tags(" in src
+        tree = _parse_module("constants.py")
+        func = _find_function_def(tree, "preview_tags")
+        assert func is not None, "preview_tags() function must be defined"
 
     def test_preview_tags_in_all(self):
         """preview_tags must be exported in __all__."""
-        src = _read_source("constants.py")
-        assert '"preview_tags"' in src or "'preview_tags'" in src
+        tree = _parse_module("constants.py")
+        all_entries = _find_all_list(tree)
+        assert "preview_tags" in all_entries
 
     def test_preview_tags_includes_auto_delete(self):
         """preview_tags() must add AutoDelete tag."""
-        src = _read_source("constants.py")
-        assert '"AutoDelete"' in src
+        tree = _parse_module("constants.py")
+        func = _find_function_def(tree, "preview_tags")
+        assert func is not None
+        func_src = ast.unparse(func)
+        assert "AutoDelete" in func_src
 
     def test_preview_tags_includes_pr(self):
         """preview_tags() must add PR tag."""
-        src = _read_source("constants.py")
-        assert '"PR"' in src
+        tree = _parse_module("constants.py")
+        func = _find_function_def(tree, "preview_tags")
+        assert func is not None
+        func_src = ast.unparse(func)
+        assert "'PR'" in func_src or '"PR"' in func_src
 
 
 # ===========================================================================
@@ -87,9 +171,11 @@ class TestPreviewTags:
         assert "preview_tags(" in src
 
     def test_service_has_tags(self):
-        """ECS Service tags must include cost tags (via _tags variable)."""
+        """ECS Service must have tags= keyword argument."""
         src = _read_source("preview.py")
-        assert "tags=_tags" in src or "tags={" in src
+        assert _find_keyword_call(src, "Service", "tags"), (
+            "preview.py ECS Service must have tags= argument"
+        )
 
 
 # ===========================================================================
@@ -112,7 +198,9 @@ class TestFrontendPreviewTags:
     def test_distribution_has_tags(self):
         """CloudFront Distribution tags must include cost tags."""
         src = _read_source("frontend_preview.py")
-        assert src.count("**_tags") >= 2
+        assert _find_keyword_call(src, "Distribution", "tags"), (
+            "frontend_preview.py Distribution must have tags= argument"
+        )
 
 
 # ===========================================================================
@@ -130,7 +218,9 @@ class TestCleanupTags:
 
     def test_lambda_has_tags(self):
         src = _read_source("cleanup.py")
-        assert "tags=" in src
+        assert _find_keyword_call(src, "Function", "tags"), (
+            "cleanup.py Lambda Function must have tags= argument"
+        )
 
 
 # ===========================================================================
@@ -148,15 +238,6 @@ class TestStaleCleanupTags:
 
     def test_lambda_has_tags(self):
         src = _read_source("stale_cleanup.py")
-        lines = src.split("\n")
-        in_lambda = False
-        has_tags = False
-        for line in lines:
-            if "aws.lambda_.Function(" in line:
-                in_lambda = True
-            if in_lambda and "tags=" in line:
-                has_tags = True
-                break
-            if in_lambda and line.strip() == ")":
-                break
-        assert has_tags, "stale_cleanup Lambda must have tags= argument"
+        assert _find_keyword_call(src, "Function", "tags"), (
+            "stale_cleanup.py Lambda Function must have tags= argument"
+        )


### PR DESCRIPTION
## Summary
- Add `ManagedBy` tag to `COST_TAGS` and create `preview_tags()` helper in `constants.py` for ephemeral preview resources (`AutoDelete`, `PR` tags)
- Apply standardized cost tags to `preview.py`, `frontend_preview.py`, `cleanup.py`, and `stale_cleanup.py` modules
- Add `tests/test_resource_tagging.py` to verify all infra modules use centralized tag helpers

## Test plan
- [ ] Run `pytest tests/test_resource_tagging.py` -- all 16 tests pass
- [ ] Run full test suite `pytest tests/` -- no regressions
- [ ] Run `ruff check` -- no lint errors
- [ ] Verify `pulumi preview` shows expected tag additions on resources

Closes #250