### PR TITLE
refactor: ♻️ unify infra module style to class-based

### DIFF
--- a/infra/cleanup.py
+++ b/infra/cleanup.py
@@ -18,81 +18,100 @@ from constants import LOG_RETENTION_DAYS, cost_tags
 iam = aws.iam
 cloudwatch = aws.cloudwatch
 
-_COST_TAGS = cost_tags(cost_center="cleanup")
 
-# --- CloudWatch Log Group for Lambda ----------------------------------------
-cleanup_log_group = common.create_log_group(
-    "myxo-pr-cleanup-logs",
-    "/aws/lambda/myxo-pr-cleanup",
-    retention_in_days=LOG_RETENTION_DAYS,
-    tags=_COST_TAGS,
-)
+# ---------------------------------------------------------------------------
+# CleanupEnvironment
+# ---------------------------------------------------------------------------
+class CleanupEnvironment:
+    """Lambda-based cleanup triggered by PR close events.
 
-# --- IAM Role for Lambda execution ------------------------------------------
-cleanup_role = common.create_lambda_role("myxo-pr-cleanup")
+    Creates an IAM role, CloudWatch log group, Lambda function,
+    and EventBridge rule+target to automatically clean up preview
+    resources when a pull request is closed.
+    """
 
-# CloudWatch Logs permissions
-common.attach_basic_execution_role("myxo-pr-cleanup", cleanup_role)
+    def __init__(self) -> None:
+        _cost_tags = cost_tags(cost_center="cleanup")
 
-# ECS task stop permissions
-iam.RolePolicy(
-    "myxo-pr-cleanup-ecs-policy",
-    role=cleanup_role.name,
-    policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
+        # --- CloudWatch Log Group for Lambda --------------------------------
+        self.log_group = common.create_log_group(
+            "myxo-pr-cleanup-logs",
+            "/aws/lambda/myxo-pr-cleanup",
+            retention_in_days=LOG_RETENTION_DAYS,
+            tags=_cost_tags,
+        )
+
+        # --- IAM Role for Lambda execution ----------------------------------
+        self.role = common.create_lambda_role("myxo-pr-cleanup")
+
+        # CloudWatch Logs permissions
+        common.attach_basic_execution_role("myxo-pr-cleanup", self.role)
+
+        # ECS task stop permissions
+        iam.RolePolicy(
+            "myxo-pr-cleanup-ecs-policy",
+            role=self.role.name,
+            policy=json.dumps(
                 {
-                    "Effect": "Allow",
-                    "Action": [
-                        "ecs:StopTask",
-                        "ecs:ListTasks",
-                        "ecs:DescribeTasks",
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "ecs:StopTask",
+                                "ecs:ListTasks",
+                                "ecs:DescribeTasks",
+                            ],
+                            "Resource": "arn:aws:ecs:*:*:task/myxo-cluster/*",
+                        }
                     ],
-                    "Resource": "arn:aws:ecs:*:*:task/myxo-cluster/*",
                 }
-            ],
-        }
-    ),
-)
+            ),
+        )
 
-# --- Lambda Function --------------------------------------------------------
-cleanup_lambda = aws.lambda_.Function(
-    "myxo-pr-cleanup",
-    function_name="myxo-pr-cleanup",
-    runtime="python3.13",
-    handler="handler.handle",
-    timeout=60,
-    memory_size=128,
-    role=cleanup_role.arn,
-    description="Clean up preview resources when PR is closed",
-    code=pulumi.AssetArchive({"handler.py": pulumi.FileAsset("../lambda/pr_cleanup/handler.py")}),
-    tags=_COST_TAGS,
-)
+        # --- Lambda Function ------------------------------------------------
+        self.cleanup_lambda = aws.lambda_.Function(
+            "myxo-pr-cleanup",
+            function_name="myxo-pr-cleanup",
+            runtime="python3.13",
+            handler="handler.handle",
+            timeout=60,
+            memory_size=128,
+            role=self.role.arn,
+            description="Clean up preview resources when PR is closed",
+            code=pulumi.AssetArchive({"handler.py": pulumi.FileAsset("../lambda/pr_cleanup/handler.py")}),
+            tags=_cost_tags,
+        )
 
-# --- EventBridge Rule -------------------------------------------------------
-pr_close_rule = cloudwatch.EventRule(
-    "myxo-pr-close-rule",
-    name="myxo-pr-close-rule",
-    description="Trigger cleanup Lambda on GitHub PR close events",
-    event_pattern=json.dumps(
-        {
-            "source": ["aws.partner/github.com"],
-            "detail-type": ["pull_request"],
-            "detail": {"action": ["closed"]},
-        }
-    ),
-)
+        # --- EventBridge Rule -----------------------------------------------
+        self.pr_close_rule = cloudwatch.EventRule(
+            "myxo-pr-close-rule",
+            name="myxo-pr-close-rule",
+            description="Trigger cleanup Lambda on GitHub PR close events",
+            event_pattern=json.dumps(
+                {
+                    "source": ["aws.partner/github.com"],
+                    "detail-type": ["pull_request"],
+                    "detail": {"action": ["closed"]},
+                }
+            ),
+        )
 
-cloudwatch.EventTarget(
-    "myxo-pr-close-target",
-    rule=pr_close_rule.name,
-    arn=cleanup_lambda.arn,
-)
+        cloudwatch.EventTarget(
+            "myxo-pr-close-target",
+            rule=self.pr_close_rule.name,
+            arn=self.cleanup_lambda.arn,
+        )
 
-# Allow EventBridge to invoke the Lambda
-common.create_eventbridge_lambda_permission("myxo-pr-cleanup", cleanup_lambda, pr_close_rule)
+        # Allow EventBridge to invoke the Lambda
+        common.create_eventbridge_lambda_permission("myxo-pr-cleanup", self.cleanup_lambda, self.pr_close_rule)
+
+
+# ---------------------------------------------------------------------------
+# Instantiate at module level so Pulumi registers resources on import
+# ---------------------------------------------------------------------------
+cleanup = CleanupEnvironment()
 
 # --- Exports ----------------------------------------------------------------
-pulumi.export("cleanup_lambda_arn", cleanup_lambda.arn)
-pulumi.export("cleanup_rule_arn", pr_close_rule.arn)
+pulumi.export("cleanup_lambda_arn", cleanup.cleanup_lambda.arn)
+pulumi.export("cleanup_rule_arn", cleanup.pr_close_rule.arn)

--- a/infra/infisical.py
+++ b/infra/infisical.py
@@ -35,155 +35,195 @@ ingress_cidr_blocks: list[str] = config.get_object("ingress_cidr_blocks") or [
     vpc_config.require("cidr_block"),
 ]
 
-_COST_TAGS = cost_tags(cost_center="secrets-management")
 
 # ---------------------------------------------------------------------------
-# SSM Parameter Store — secrets for ECS container
+# InfisicalServer
 # ---------------------------------------------------------------------------
-ssm_mongo_url = aws.ssm.Parameter(
-    "infisical-ssm-mongo-url",
-    name=f"/infisical/{pulumi.get_stack()}/MONGO_URL",
-    type="SecureString",
-    value=mongo_url,
-    tags=_COST_TAGS,
-)
+class InfisicalServer:
+    """Self-hosted Infisical secrets manager on ECS Fargate.
 
-ssm_encryption_key = aws.ssm.Parameter(
-    "infisical-ssm-encryption-key",
-    name=f"/infisical/{pulumi.get_stack()}/ENCRYPTION_KEY",
-    type="SecureString",
-    value=encryption_key,
-    tags=_COST_TAGS,
-)
+    Parameters
+    ----------
+    vpc_id:
+        VPC ID for the security group.
+    subnet_ids:
+        List of private subnet IDs for awsvpc networking.
+    ingress_cidr_blocks:
+        CIDR blocks allowed for inbound HTTPS traffic.
+    mongo_url:
+        MongoDB connection URL (Pulumi secret).
+    encryption_key:
+        Infisical encryption key (Pulumi secret).
+    auth_secret:
+        Infisical auth secret (Pulumi secret).
+    site_url:
+        Public URL for the Infisical instance.
+    """
 
-ssm_auth_secret = aws.ssm.Parameter(
-    "infisical-ssm-auth-secret",
-    name=f"/infisical/{pulumi.get_stack()}/AUTH_SECRET",
-    type="SecureString",
-    value=auth_secret,
-    tags=_COST_TAGS,
-)
+    def __init__(
+        self,
+        *,
+        vpc_id: pulumi.Input[str],
+        subnet_ids: list[str],
+        ingress_cidr_blocks: list[str],
+        mongo_url: pulumi.Input[str],
+        encryption_key: pulumi.Input[str],
+        auth_secret: pulumi.Input[str],
+        site_url: str,
+    ) -> None:
+        _cost_tags = cost_tags(cost_center="secrets-management")
 
-# ---------------------------------------------------------------------------
-# CloudWatch Log Group
-# ---------------------------------------------------------------------------
-log_group = common.create_log_group(
-    "infisical-log-group",
-    "/ecs/infisical",
-    retention_in_days=LOG_RETENTION_DAYS,
-    tags=_COST_TAGS,
-)
+        # --- SSM Parameter Store — secrets for ECS container ----------------
+        self.ssm_mongo_url = aws.ssm.Parameter(
+            "infisical-ssm-mongo-url",
+            name=f"/infisical/{pulumi.get_stack()}/MONGO_URL",
+            type="SecureString",
+            value=mongo_url,
+            tags=_cost_tags,
+        )
 
-# ---------------------------------------------------------------------------
-# Security Group — allow inbound 443 (HTTPS) from configurable CIDR
-# ---------------------------------------------------------------------------
-infisical_sg = aws.ec2.SecurityGroup(
-    "infisical-sg",
-    name="infisical-sg",
-    description="Allow inbound HTTPS traffic to Infisical",
-    vpc_id=vpc_id,
-    ingress=[
-        aws.ec2.SecurityGroupIngressArgs(
-            protocol="tcp",
-            from_port=443,
-            to_port=443,
-            cidr_blocks=ingress_cidr_blocks,
-            description="HTTPS inbound from configured CIDR",
-        ),
-    ],
-    egress=[
-        aws.ec2.SecurityGroupEgressArgs(
-            protocol="-1",
-            from_port=0,
-            to_port=0,
-            cidr_blocks=["0.0.0.0/0"],
-            description="Allow all outbound",
-        ),
-    ],
-    tags={"Name": "infisical-sg", **_COST_TAGS},
-)
+        self.ssm_encryption_key = aws.ssm.Parameter(
+            "infisical-ssm-encryption-key",
+            name=f"/infisical/{pulumi.get_stack()}/ENCRYPTION_KEY",
+            type="SecureString",
+            value=encryption_key,
+            tags=_cost_tags,
+        )
 
-# ---------------------------------------------------------------------------
-# ECS Task Definition
-# ---------------------------------------------------------------------------
-aws_config = pulumi.Config("aws")
-_region = aws_config.require("region")
+        self.ssm_auth_secret = aws.ssm.Parameter(
+            "infisical-ssm-auth-secret",
+            name=f"/infisical/{pulumi.get_stack()}/AUTH_SECRET",
+            type="SecureString",
+            value=auth_secret,
+            tags=_cost_tags,
+        )
 
-container_definitions = pulumi.Output.all(
-    log_group.name,
-    ssm_mongo_url.arn,
-    ssm_encryption_key.arn,
-    ssm_auth_secret.arn,
-).apply(
-    lambda args: json.dumps(
-        [
-            {
-                "name": "infisical",
-                "image": "infisical/infisical:v0.91.0",
-                "cpu": 512,
-                "memory": 1024,
-                "essential": True,
-                "portMappings": [
+        # --- CloudWatch Log Group -------------------------------------------
+        self.log_group = common.create_log_group(
+            "infisical-log-group",
+            "/ecs/infisical",
+            retention_in_days=LOG_RETENTION_DAYS,
+            tags=_cost_tags,
+        )
+
+        # --- Security Group — allow inbound 443 (HTTPS) --------------------
+        self.security_group = aws.ec2.SecurityGroup(
+            "infisical-sg",
+            name="infisical-sg",
+            description="Allow inbound HTTPS traffic to Infisical",
+            vpc_id=vpc_id,
+            ingress=[
+                aws.ec2.SecurityGroupIngressArgs(
+                    protocol="tcp",
+                    from_port=443,
+                    to_port=443,
+                    cidr_blocks=ingress_cidr_blocks,
+                    description="HTTPS inbound from configured CIDR",
+                ),
+            ],
+            egress=[
+                aws.ec2.SecurityGroupEgressArgs(
+                    protocol="-1",
+                    from_port=0,
+                    to_port=0,
+                    cidr_blocks=["0.0.0.0/0"],
+                    description="Allow all outbound",
+                ),
+            ],
+            tags={"Name": "infisical-sg", **_cost_tags},
+        )
+
+        # --- ECS Task Definition --------------------------------------------
+        aws_config = pulumi.Config("aws")
+        _region = aws_config.require("region")
+
+        container_definitions = pulumi.Output.all(
+            self.log_group.name,
+            self.ssm_mongo_url.arn,
+            self.ssm_encryption_key.arn,
+            self.ssm_auth_secret.arn,
+        ).apply(
+            lambda args: json.dumps(
+                [
                     {
-                        "containerPort": 443,
-                        "protocol": "tcp",
+                        "name": "infisical",
+                        "image": "infisical/infisical:v0.91.0",
+                        "cpu": 512,
+                        "memory": 1024,
+                        "essential": True,
+                        "portMappings": [
+                            {
+                                "containerPort": 443,
+                                "protocol": "tcp",
+                            }
+                        ],
+                        "environment": [
+                            {"name": "SITE_URL", "value": site_url},
+                            {"name": "NODE_ENV", "value": "production"},
+                        ],
+                        "secrets": [
+                            {"name": "MONGO_URL", "valueFrom": args[1]},
+                            {"name": "ENCRYPTION_KEY", "valueFrom": args[2]},
+                            {"name": "AUTH_SECRET", "valueFrom": args[3]},
+                        ],
+                        "logConfiguration": {
+                            "logDriver": "awslogs",
+                            "options": {
+                                "awslogs-group": args[0],
+                                "awslogs-region": _region,
+                                "awslogs-stream-prefix": "infisical",
+                            },
+                        },
                     }
-                ],
-                "environment": [
-                    {"name": "SITE_URL", "value": site_url},
-                    {"name": "NODE_ENV", "value": "production"},
-                ],
-                "secrets": [
-                    {"name": "MONGO_URL", "valueFrom": args[1]},
-                    {"name": "ENCRYPTION_KEY", "valueFrom": args[2]},
-                    {"name": "AUTH_SECRET", "valueFrom": args[3]},
-                ],
-                "logConfiguration": {
-                    "logDriver": "awslogs",
-                    "options": {
-                        "awslogs-group": args[0],
-                        "awslogs-region": _region,
-                        "awslogs-stream-prefix": "infisical",
-                    },
-                },
-            }
-        ]
-    )
-)
+                ]
+            )
+        )
 
-task_definition = aws.ecs.TaskDefinition(
-    "infisical-task",
-    family="infisical-task",
-    cpu="512",
-    memory="1024",
-    network_mode="awsvpc",
-    requires_compatibilities=["FARGATE"],
-    execution_role_arn=ecs_infra.task_execution_role.arn,
-    task_role_arn=ecs_infra.task_role.arn,
-    container_definitions=container_definitions,
-    tags=_COST_TAGS,
-)
+        self.task_definition = aws.ecs.TaskDefinition(
+            "infisical-task",
+            family="infisical-task",
+            cpu="512",
+            memory="1024",
+            network_mode="awsvpc",
+            requires_compatibilities=["FARGATE"],
+            execution_role_arn=ecs_infra.task_execution_role.arn,
+            task_role_arn=ecs_infra.task_role.arn,
+            container_definitions=container_definitions,
+            tags=_cost_tags,
+        )
+
+        # --- ECS Service ----------------------------------------------------
+        self.service = aws.ecs.Service(
+            "infisical-service",
+            name="infisical-service",
+            cluster=ecs_infra.cluster.arn,
+            task_definition=self.task_definition.arn,
+            desired_count=1,
+            launch_type="FARGATE",
+            network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
+                assign_public_ip=False,
+                security_groups=[self.security_group.id],
+                subnets=subnet_ids,
+            ),
+            tags=_cost_tags,
+        )
+
 
 # ---------------------------------------------------------------------------
-# ECS Service
+# Instantiate at module level so Pulumi registers resources on import
 # ---------------------------------------------------------------------------
-infisical_service = aws.ecs.Service(
-    "infisical-service",
-    name="infisical-service",
-    cluster=ecs_infra.cluster.arn,
-    task_definition=task_definition.arn,
-    desired_count=1,
-    launch_type="FARGATE",
-    network_configuration=aws.ecs.ServiceNetworkConfigurationArgs(
-        assign_public_ip=False,
-        security_groups=[infisical_sg.id],
-        subnets=subnet_ids,
-    ),
-    tags=_COST_TAGS,
+infisical = InfisicalServer(
+    vpc_id=vpc_id,
+    subnet_ids=subnet_ids,
+    ingress_cidr_blocks=ingress_cidr_blocks,
+    mongo_url=mongo_url,
+    encryption_key=encryption_key,
+    auth_secret=auth_secret,
+    site_url=site_url,
 )
 
 # ---------------------------------------------------------------------------
 # Exports
 # ---------------------------------------------------------------------------
-pulumi.export("infisical_service_name", infisical_service.name)
-pulumi.export("infisical_task_definition_arn", task_definition.arn)
+pulumi.export("infisical_service_name", infisical.service.name)
+pulumi.export("infisical_task_definition_arn", infisical.task_definition.arn)

--- a/infra/stale_cleanup.py
+++ b/infra/stale_cleanup.py
@@ -18,91 +18,110 @@ import pulumi
 import pulumi_aws as aws
 from constants import LOG_RETENTION_DAYS, cost_tags
 
-_COST_TAGS = cost_tags(cost_center="cleanup")
 
-# --- IAM Role for Lambda ---------------------------------------------------
-cleanup_role = common.create_lambda_role("myxo-stale-cleanup")
+# ---------------------------------------------------------------------------
+# StaleCleanupEnvironment
+# ---------------------------------------------------------------------------
+class StaleCleanupEnvironment:
+    """Lambda-based stale resource cleanup on a daily schedule.
 
-# Basic Lambda execution (CloudWatch Logs)
-common.attach_basic_execution_role("myxo-stale-cleanup", cleanup_role)
+    Creates an IAM role, CloudWatch log group, Lambda function,
+    and EventBridge schedule rule+target to scan for and remove
+    AWS resources tagged with AutoDelete=true past their expiry.
+    """
 
-# Inline policy for ECS + EC2 describe/delete with AutoDelete tag
-aws.iam.RolePolicy(
-    "myxo-stale-cleanup-policy",
-    role=cleanup_role.id,
-    policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
+    def __init__(self) -> None:
+        _cost_tags = cost_tags(cost_center="cleanup")
+
+        # --- IAM Role for Lambda -------------------------------------------
+        self.role = common.create_lambda_role("myxo-stale-cleanup")
+
+        # Basic Lambda execution (CloudWatch Logs)
+        common.attach_basic_execution_role("myxo-stale-cleanup", self.role)
+
+        # Inline policy for ECS + EC2 describe/delete with AutoDelete tag
+        aws.iam.RolePolicy(
+            "myxo-stale-cleanup-policy",
+            role=self.role.id,
+            policy=json.dumps(
                 {
-                    "Effect": "Allow",
-                    "Action": [
-                        "ecs:DescribeTasks",
-                        "ecs:ListTasks",
-                        "ec2:DescribeInstances",
-                        "tag:GetResources",
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "ecs:DescribeTasks",
+                                "ecs:ListTasks",
+                                "ec2:DescribeInstances",
+                                "tag:GetResources",
+                            ],
+                            "Sid": "ReadOnlyStaleResources",
+                            "Resource": "*",
+                            "Condition": {
+                                "StringEquals": {
+                                    "aws:ResourceTag/AutoDelete": "true",
+                                }
+                            },
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "tag:GetResources",
+                                "ecs:ListTasks",
+                                "ecs:ListClusters",
+                            ],
+                            "Resource": "*",
+                        },
                     ],
-                    "Sid": "ReadOnlyStaleResources",
-                    "Resource": "*",
-                    "Condition": {
-                        "StringEquals": {
-                            "aws:ResourceTag/AutoDelete": "true",
-                        }
-                    },
-                },
-                {
-                    "Effect": "Allow",
-                    "Action": [
-                        "tag:GetResources",
-                        "ecs:ListTasks",
-                        "ecs:ListClusters",
-                    ],
-                    "Resource": "*",
-                },
-            ],
-        }
-    ),
-)
+                }
+            ),
+        )
 
-# --- CloudWatch Log Group --------------------------------------------------
-cleanup_log_group = common.create_log_group(
-    "myxo-stale-cleanup-logs",
-    "/aws/lambda/myxo-stale-cleanup",
-    retention_in_days=LOG_RETENTION_DAYS,
-    tags=_COST_TAGS,
-)
+        # --- CloudWatch Log Group ------------------------------------------
+        self.log_group = common.create_log_group(
+            "myxo-stale-cleanup-logs",
+            "/aws/lambda/myxo-stale-cleanup",
+            retention_in_days=LOG_RETENTION_DAYS,
+            tags=_cost_tags,
+        )
 
-# --- Lambda Function -------------------------------------------------------
-cleanup_function = aws.lambda_.Function(
-    "myxo-stale-cleanup",
-    function_name="myxo-stale-cleanup",
-    runtime="python3.13",
-    handler="handler.handle",
-    timeout=300,
-    memory_size=128,
-    role=cleanup_role.arn,
-    code=pulumi.AssetArchive({".": pulumi.FileArchive("../lambda/stale_cleanup")}),
-    tags=_COST_TAGS,
-)
+        # --- Lambda Function -----------------------------------------------
+        self.cleanup_function = aws.lambda_.Function(
+            "myxo-stale-cleanup",
+            function_name="myxo-stale-cleanup",
+            runtime="python3.13",
+            handler="handler.handle",
+            timeout=300,
+            memory_size=128,
+            role=self.role.arn,
+            code=pulumi.AssetArchive({".": pulumi.FileArchive("../lambda/stale_cleanup")}),
+            tags=_cost_tags,
+        )
 
-# --- EventBridge Schedule Rule ---------------------------------------------
-schedule_rule = aws.cloudwatch.EventRule(
-    "myxo-stale-cleanup-schedule",
-    name="myxo-stale-cleanup-schedule",
-    description="Run stale resource cleanup daily at 03:00 UTC",
-    schedule_expression="cron(0 3 * * ? *)",
-)
+        # --- EventBridge Schedule Rule -------------------------------------
+        self.schedule_rule = aws.cloudwatch.EventRule(
+            "myxo-stale-cleanup-schedule",
+            name="myxo-stale-cleanup-schedule",
+            description="Run stale resource cleanup daily at 03:00 UTC",
+            schedule_expression="cron(0 3 * * ? *)",
+        )
 
-# --- EventBridge Target ----------------------------------------------------
-aws.cloudwatch.EventTarget(
-    "myxo-stale-cleanup-target",
-    rule=schedule_rule.name,
-    arn=cleanup_function.arn,
-)
+        # --- EventBridge Target --------------------------------------------
+        aws.cloudwatch.EventTarget(
+            "myxo-stale-cleanup-target",
+            rule=self.schedule_rule.name,
+            arn=self.cleanup_function.arn,
+        )
 
-# --- Lambda Permission for EventBridge ------------------------------------
-common.create_eventbridge_lambda_permission("myxo-stale-cleanup", cleanup_function, schedule_rule)
+        # --- Lambda Permission for EventBridge ----------------------------
+        common.create_eventbridge_lambda_permission("myxo-stale-cleanup", self.cleanup_function, self.schedule_rule)
+
+
+# ---------------------------------------------------------------------------
+# Instantiate at module level so Pulumi registers resources on import
+# ---------------------------------------------------------------------------
+stale_cleanup = StaleCleanupEnvironment()
 
 # --- Exports ---------------------------------------------------------------
-pulumi.export("stale_cleanup_function_arn", cleanup_function.arn)
-pulumi.export("stale_cleanup_schedule_rule", schedule_rule.name)
+pulumi.export("stale_cleanup_function_arn", stale_cleanup.cleanup_function.arn)
+pulumi.export("stale_cleanup_schedule_rule", stale_cleanup.schedule_rule.name)

--- a/infra/stale_cleanup.py
+++ b/infra/stale_cleanup.py
@@ -42,7 +42,7 @@ class StaleCleanupEnvironment:
         # Inline policy for ECS + EC2 describe/delete with AutoDelete tag
         aws.iam.RolePolicy(
             "myxo-stale-cleanup-policy",
-            role=self.role.id,
+            role=self.role.name,
             policy=json.dumps(
                 {
                     "Version": "2012-10-17",

--- a/tests/test_infra_class_style.py
+++ b/tests/test_infra_class_style.py
@@ -1,0 +1,122 @@
+"""Tests to verify all infra modules use class-based style (#255).
+
+Ensures cleanup.py, stale_cleanup.py, and infisical.py follow the same
+class-based pattern used in preview.py and frontend_preview.py.
+"""
+
+import ast
+from pathlib import Path
+
+INFRA_DIR = Path(__file__).resolve().parent.parent / "infra"
+
+# ---------------------------------------------------------------------------
+# Helper — extract class names from a module via AST
+# ---------------------------------------------------------------------------
+
+
+def _class_names(module_path: Path) -> list[str]:
+    """Return top-level class names defined in *module_path*."""
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(module_path))
+    return [node.name for node in ast.iter_child_nodes(tree) if isinstance(node, ast.ClassDef)]
+
+
+# ---------------------------------------------------------------------------
+# cleanup.py — must define CleanupEnvironment class
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_has_class():
+    """cleanup.py must define a CleanupEnvironment class."""
+    classes = _class_names(INFRA_DIR / "cleanup.py")
+    assert "CleanupEnvironment" in classes, f"cleanup.py must define CleanupEnvironment class, found: {classes}"
+
+
+def test_cleanup_class_instantiated_at_module_level():
+    """cleanup.py must instantiate CleanupEnvironment at module level."""
+    source = (INFRA_DIR / "cleanup.py").read_text(encoding="utf-8")
+    assert "CleanupEnvironment(" in source, "CleanupEnvironment must be instantiated at module level"
+
+
+def test_cleanup_class_has_init():
+    """CleanupEnvironment must define __init__."""
+    source = (INFRA_DIR / "cleanup.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "CleanupEnvironment":
+            methods = [n.name for n in ast.iter_child_nodes(node) if isinstance(n, ast.FunctionDef)]
+            assert "__init__" in methods, "CleanupEnvironment must define __init__"
+            return
+    raise AssertionError("CleanupEnvironment class not found")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# stale_cleanup.py — must define StaleCleanupEnvironment class
+# ---------------------------------------------------------------------------
+
+
+def test_stale_cleanup_has_class():
+    """stale_cleanup.py must define a StaleCleanupEnvironment class."""
+    classes = _class_names(INFRA_DIR / "stale_cleanup.py")
+    assert "StaleCleanupEnvironment" in classes, (
+        f"stale_cleanup.py must define StaleCleanupEnvironment class, found: {classes}"
+    )
+
+
+def test_stale_cleanup_class_instantiated_at_module_level():
+    """stale_cleanup.py must instantiate StaleCleanupEnvironment at module level."""
+    source = (INFRA_DIR / "stale_cleanup.py").read_text(encoding="utf-8")
+    assert "StaleCleanupEnvironment(" in source, "StaleCleanupEnvironment must be instantiated at module level"
+
+
+def test_stale_cleanup_class_has_init():
+    """StaleCleanupEnvironment must define __init__."""
+    source = (INFRA_DIR / "stale_cleanup.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "StaleCleanupEnvironment":
+            methods = [n.name for n in ast.iter_child_nodes(node) if isinstance(n, ast.FunctionDef)]
+            assert "__init__" in methods, "StaleCleanupEnvironment must define __init__"
+            return
+    raise AssertionError("StaleCleanupEnvironment class not found")
+
+
+# ---------------------------------------------------------------------------
+# infisical.py — must define InfisicalServer class
+# ---------------------------------------------------------------------------
+
+
+def test_infisical_has_class():
+    """infisical.py must define an InfisicalServer class."""
+    classes = _class_names(INFRA_DIR / "infisical.py")
+    assert "InfisicalServer" in classes, f"infisical.py must define InfisicalServer class, found: {classes}"
+
+
+def test_infisical_class_instantiated_at_module_level():
+    """infisical.py must instantiate InfisicalServer at module level."""
+    source = (INFRA_DIR / "infisical.py").read_text(encoding="utf-8")
+    assert "InfisicalServer(" in source, "InfisicalServer must be instantiated at module level"
+
+
+def test_infisical_class_has_init():
+    """InfisicalServer must define __init__."""
+    source = (INFRA_DIR / "infisical.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "InfisicalServer":
+            methods = [n.name for n in ast.iter_child_nodes(node) if isinstance(n, ast.FunctionDef)]
+            assert "__init__" in methods, "InfisicalServer must define __init__"
+            return
+    raise AssertionError("InfisicalServer class not found")
+
+
+# ---------------------------------------------------------------------------
+# All infra modules must use read_text(encoding="utf-8") — not bare read_text()
+# ---------------------------------------------------------------------------
+
+
+def test_existing_tests_use_encoding_utf8():
+    """Test files reading infra source must specify encoding='utf-8'."""
+    # This test validates its own helper uses encoding param
+    source = Path(__file__).read_text(encoding="utf-8")
+    assert 'encoding="utf-8"' in source

--- a/tests/test_infra_class_style.py
+++ b/tests/test_infra_class_style.py
@@ -21,6 +21,25 @@ def _class_names(module_path: Path) -> list[str]:
     return [node.name for node in ast.iter_child_nodes(tree) if isinstance(node, ast.ClassDef)]
 
 
+def _has_module_level_instantiation(module_path: Path, class_name: str) -> bool:
+    """Check if *class_name* is instantiated at module level via AST.
+
+    Looks for a top-level ``ast.Assign`` or ``ast.AnnAssign`` whose value
+    is an ``ast.Call`` to *class_name*.
+    """
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(module_path))
+    for node in ast.iter_child_nodes(tree):
+        call_node = None
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.Expr)) and isinstance(node.value, ast.Call):
+            call_node = node.value
+        if call_node is not None:
+            func_name = ast.unparse(call_node.func)
+            if func_name == class_name:
+                return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # cleanup.py — must define CleanupEnvironment class
 # ---------------------------------------------------------------------------
@@ -34,8 +53,9 @@ def test_cleanup_has_class():
 
 def test_cleanup_class_instantiated_at_module_level():
     """cleanup.py must instantiate CleanupEnvironment at module level."""
-    source = (INFRA_DIR / "cleanup.py").read_text(encoding="utf-8")
-    assert "CleanupEnvironment(" in source, "CleanupEnvironment must be instantiated at module level"
+    assert _has_module_level_instantiation(INFRA_DIR / "cleanup.py", "CleanupEnvironment"), (
+        "CleanupEnvironment must be instantiated at module level"
+    )
 
 
 def test_cleanup_class_has_init():
@@ -65,8 +85,9 @@ def test_stale_cleanup_has_class():
 
 def test_stale_cleanup_class_instantiated_at_module_level():
     """stale_cleanup.py must instantiate StaleCleanupEnvironment at module level."""
-    source = (INFRA_DIR / "stale_cleanup.py").read_text(encoding="utf-8")
-    assert "StaleCleanupEnvironment(" in source, "StaleCleanupEnvironment must be instantiated at module level"
+    assert _has_module_level_instantiation(INFRA_DIR / "stale_cleanup.py", "StaleCleanupEnvironment"), (
+        "StaleCleanupEnvironment must be instantiated at module level"
+    )
 
 
 def test_stale_cleanup_class_has_init():
@@ -94,8 +115,9 @@ def test_infisical_has_class():
 
 def test_infisical_class_instantiated_at_module_level():
     """infisical.py must instantiate InfisicalServer at module level."""
-    source = (INFRA_DIR / "infisical.py").read_text(encoding="utf-8")
-    assert "InfisicalServer(" in source, "InfisicalServer must be instantiated at module level"
+    assert _has_module_level_instantiation(INFRA_DIR / "infisical.py", "InfisicalServer"), (
+        "InfisicalServer must be instantiated at module level"
+    )
 
 
 def test_infisical_class_has_init():
@@ -111,12 +133,19 @@ def test_infisical_class_has_init():
 
 
 # ---------------------------------------------------------------------------
-# All infra modules must use read_text(encoding="utf-8") — not bare read_text()
+# All read_text() calls in this test file must specify encoding="utf-8"
 # ---------------------------------------------------------------------------
 
 
 def test_existing_tests_use_encoding_utf8():
-    """Test files reading infra source must specify encoding='utf-8'."""
-    # This test validates its own helper uses encoding param
+    """Every read_text() call in this file must specify encoding='utf-8'."""
     source = Path(__file__).read_text(encoding="utf-8")
-    assert 'encoding="utf-8"' in source
+    tree = ast.parse(source, filename=str(Path(__file__)))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "read_text":
+            encoding_kw = next((kw for kw in node.keywords if kw.arg == "encoding"), None)
+            assert encoding_kw is not None, f"read_text() at line {node.lineno} must specify encoding='utf-8'"
+            if isinstance(encoding_kw.value, ast.Constant):
+                assert encoding_kw.value.value == "utf-8", (
+                    f"read_text() at line {node.lineno}: encoding must be 'utf-8'"
+                )


### PR DESCRIPTION
## Summary
- Convert cleanup.py, stale_cleanup.py, and infisical.py from procedural to class-based style matching preview.py and frontend_preview.py
- Each module defines a class (CleanupEnvironment, StaleCleanupEnvironment, InfisicalServer) instantiated at module level
- Add tests/test_infra_class_style.py with AST-based class structure verification tests

## Test plan
- [x] All 9 new class-style tests pass
- [x] All existing infra tests pass unchanged (419 total)
- [x] ruff check and ruff format pass

Closes #255